### PR TITLE
Fix: Display dynamic user profile name and resolve checklist multiple…

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
 import PlusIcon from './icons/PlusIcon';
 
 interface HeaderProps {
@@ -15,6 +16,14 @@ const Header: React.FC<HeaderProps> = ({
   onOpenAddModal,
   onOpenScannerModal
 }) => {
+  const { user } = useAuth();
+  let initials = 'U';
+  if (user?.user_metadata?.full_name) {
+    initials = user.user_metadata.full_name.split(' ').map(n => n[0]).join('').substring(0, 2).toUpperCase();
+  } else if (user?.email) {
+    initials = user.email.substring(0, 2).toUpperCase();
+  }
+
   return (
     <header className="bg-gray-900 border-b border-gray-800 px-4 py-3">
       <div className="flex items-center justify-between">
@@ -79,7 +88,7 @@ const Header: React.FC<HeaderProps> = ({
           {/* Profile */}
           <Link to="/profile" className="flex items-center space-x-2">
             <div className="w-8 h-8 rounded-full bg-emerald-700 flex items-center justify-center text-white text-xs font-medium">
-              JS
+              {initials}
             </div>
           </Link>
         </div>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
 
 // Icons
 import LeafIcon from './icons/LeafIcon';
@@ -11,6 +12,15 @@ interface SidebarProps {
 
 const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose }) => {
   const location = useLocation();
+  const { user } = useAuth();
+
+  const displayName = user?.user_metadata?.full_name || user?.email || 'Usuário';
+  let initials = 'U'; // Default to 'U' for Usuário
+  if (user?.user_metadata?.full_name) {
+    initials = user.user_metadata.full_name.split(' ').map(n => n[0]).join('').substring(0, 2).toUpperCase();
+  } else if (user?.email) {
+    initials = user.email.substring(0, 2).toUpperCase();
+  }
   
   // Define navigation items with icons
   const navItems = [
@@ -92,11 +102,10 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose }) => {
         <div className="absolute bottom-0 left-0 right-0 p-4 border-t border-gray-700">
           <div className="flex items-center space-x-3">
             <div className="w-10 h-10 rounded-full bg-emerald-700 flex items-center justify-center text-white font-medium">
-              JS
+              {initials}
             </div>
             <div className="flex-1">
-              <div className="text-sm font-medium text-white">John Smith</div>
-              <div className="text-xs text-gray-400">Master Grower</div>
+              <div className="text-sm font-medium text-white">{displayName}</div>
             </div>
           </div>
         </div>

--- a/pages/PlantDetailPage.tsx
+++ b/pages/PlantDetailPage.tsx
@@ -126,14 +126,15 @@ const PlantDetailPage: React.FC = () => {
 
         // THEN check if there's anything left to send
         if (Object.keys(payload).length > 0) {
-          updatePlantDetails(plantId, payload);
+          // updatePlantDetails(plantId, payload); // <-- THIS LINE IS REMOVED/COMMENTED OUT
+          console.log('[PlantDetailPage] useEffect cleanup: Would have updated with payload:', payload, 'Snapshot was:', currentChecklistSnapshot);
         } else {
           // This log should now correctly trigger if the snapshot leads to an empty payload
-          console.log('[PlantDetailPage] useEffect cleanup: Payload effectively empty after stripping undefineds, not calling updatePlantDetails. Snapshot was:', currentChecklistSnapshot);
+          console.log('[PlantDetailPage] useEffect cleanup: Payload effectively empty after stripping undefineds. Snapshot was:', currentChecklistSnapshot);
         }
       } else {
         // Log if plantId or plant is missing
-        console.log('[PlantDetailPage] useEffect cleanup: plantId or plant missing, not calling updatePlantDetails. plantId:', plantId, 'plant:', plant);
+        console.log('[PlantDetailPage] useEffect cleanup: plantId or plant missing. plantId:', plantId, 'plant:', plant);
       }
     };
   }, [plantId, plant, checklistState, updatePlantDetails]); // Added updatePlantDetails to dependencies


### PR DESCRIPTION
… updates

1. Profile Display:
   - Modified `Sidebar.tsx` and `Header.tsx` to use `useAuth`.
   - Your full name (or email/fallback) and initials are now displayed instead of hardcoded values ('John Smith', 'JS').
   - Removed static 'Master Grower' role from Sidebar.

2. Daily Checklist:
   - Removed the redundant `updatePlantDetails` call from the `useEffect` cleanup function in `PlantDetailPage.tsx`.
   - `handleTaskToggle` is now the sole function responsible for saving checklist item changes upon your interaction.
   - This addresses the issue of multiple successful `updatePlant` calls being made for a single checklist toggle.