### PR TITLE
Fix: Use path alias for dynamic import of pdfUtils

### DIFF
--- a/pages/CultivoDetailPage.tsx
+++ b/pages/CultivoDetailPage.tsx
@@ -87,7 +87,7 @@ const CultivoDetailPage: React.FC = () => {
     setToast({ message: 'Gerando PDF com QR codes...', type: 'info' });
     try {
       // Dynamically import the PDF generation utility
-      const { generateQRCodesPDF } = await import('@/src/utils/pdfUtils.ts'); // Ensure path is correct
+      const { generateQRCodesPDF } = await import('@/utils/pdfUtils.ts'); // Ensure path is correct
       await generateQRCodesPDF(plants, cultivo.name);
       // Success toast is optional as download starts
     } catch (error: any) {

--- a/pages/CultivoDetailPage.tsx
+++ b/pages/CultivoDetailPage.tsx
@@ -87,7 +87,7 @@ const CultivoDetailPage: React.FC = () => {
     setToast({ message: 'Gerando PDF com QR codes...', type: 'info' });
     try {
       // Dynamically import the PDF generation utility
-      const { generateQRCodesPDF } = await import('../utils/pdfUtils.ts'); // Ensure path is correct
+      const { generateQRCodesPDF } = await import('@/src/utils/pdfUtils.ts'); // Ensure path is correct
       await generateQRCodesPDF(plants, cultivo.name);
       // Success toast is optional as download starts
     } catch (error: any) {


### PR DESCRIPTION
I updated the dynamic import in `CultivoDetailPage.tsx` to use the path alias `@/src/utils/pdfUtils.ts` instead of a relative path.

The `@` alias points to the project root, so `@/src/utils/pdfUtils.ts` correctly targets the file. This change aims to provide a more stable path resolution for Vite/Rollup during the Netlify build process and resolve the "Could not resolve" error for this dynamically imported module.