### PR TITLE
feat: Implementa campo de substrato como dropdown com opção 'Outro'

### DIFF
--- a/pages/NovaPlantaPage.tsx
+++ b/pages/NovaPlantaPage.tsx
@@ -31,7 +31,7 @@ export default function NovaPlantaPage() {
   }, [toast]);
 
   // Handler para submissão do formulário usando o método principal
-  const handlePlantaSubmit = async (values: { name: string; strain: string; birthDate: string }) => {
+  const handlePlantaSubmit = async (values: { name: string; strain: string; birthDate: string; substrate: string }) => {
     if (!cultivoId) {
       setToast({ message: 'ID do cultivo não encontrado', type: 'error' });
       return;


### PR DESCRIPTION
- Adiciona lista de opções predefinidas para o campo substrato.
- Modifica PlantaForm.tsx para usar um <select> para substrato, incluindo uma opção 'Outro' que revela um campo de texto para entrada manual.
- Atualiza lógica de estado, inicialização (para edição) e submissão no PlantaForm.
- Ajusta NovaPlantaPage.tsx para lidar com o novo campo substrate.