### PR TITLE
refactor: Adiciona data-testid aos campos de substrato em PlantaForm

### DIFF
--- a/components/PlantaForm.tsx
+++ b/components/PlantaForm.tsx
@@ -117,6 +117,7 @@ export default function PlantaForm({ initialValues, onSubmit, loading }: PlantaF
                 setOtherSubstrate('');
               }
             }}
+            data-testid="substrate-select" // Adicionado
           >
             {SUBSTRATE_OPTIONS.map(option => (
               <option key={option.value} value={option.value}>
@@ -139,6 +140,7 @@ export default function PlantaForm({ initialValues, onSubmit, loading }: PlantaF
               value={otherSubstrate}
               onChange={(e) => setOtherSubstrate(e.target.value)}
               required={substrate === 'Outro'} // Torna obrigatório se 'Outro' for selecionado
+              data-testid="other-substrate-input" // Adicionado
             />
           </div>
         )}


### PR DESCRIPTION
- Adiciona data-testid="substrate-select" ao dropdown de substrato.
- Adiciona data-testid="other-substrate-input" ao campo de texto condicional para 'Outro' substrato.

Estas adições visam facilitar a inspeção do DOM e a depuração do problema em que o campo de substrato não aparece como um dropdown no seu ambiente.