### PR TITLE
Fix missing SpeechRecognition types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "@netlify/functions": "^3.1.10",
+        "@types/dom-speech-recognition": "^0.0.6",
         "@types/node": "^22.14.0",
         "@types/qrcode": "^1.5.5",
         "@types/react": "^19.1.6",
@@ -2448,6 +2449,13 @@
       "dependencies": {
         "@babel/types": "^7.20.7"
       }
+    },
+    "node_modules/@types/dom-speech-recognition": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/dom-speech-recognition/-/dom-speech-recognition-0.0.6.tgz",
+      "integrity": "sha512-o7pAVq9UQPJL5RDjO1f/fcpfFHdgiMnR4PoIU2N/ZQrYOS3C5rzdOJMsrpqeBCbii2EE9mERXgqspQqPDdPahw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/emscripten": {
       "version": "1.40.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@netlify/functions": "^3.1.10",
+    "@types/dom-speech-recognition": "^0.0.6",
     "@types/node": "^22.14.0",
     "@types/qrcode": "^1.5.5",
     "@types/react": "^19.1.6",


### PR DESCRIPTION
## Summary
- install `@types/dom-speech-recognition` to provide Web Speech API types

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_683f7114f5a4832aad933da34eb890f7