### PR TITLE
Implement persistent last-plant info

### DIFF
--- a/components/HamburgerMenu.tsx
+++ b/components/HamburgerMenu.tsx
@@ -12,6 +12,20 @@ interface HamburgerMenuProps {
 
 const HamburgerMenu: React.FC<HamburgerMenuProps> = ({ isOpen, onClose }) => {
   const auth = useAuth();
+  const [lastPlantId, setLastPlantId] = React.useState<string | null>(null);
+  const [lastPlantName, setLastPlantName] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (typeof window !== 'undefined') {
+      try {
+        setLastPlantId(localStorage.getItem('lastPlantId'));
+        setLastPlantName(localStorage.getItem('lastPlantName'));
+      } catch {
+        setLastPlantId(null);
+        setLastPlantName(null);
+      }
+    }
+  }, []);
 
   const handleLogout = () => {
     auth.logout();
@@ -73,13 +87,13 @@ const HamburgerMenu: React.FC<HamburgerMenuProps> = ({ isOpen, onClose }) => {
             >
               Estatísticas do Jardim
             </Link>
-            {/* Estatísticas da Planta - TODO: tornar dinâmico pelo último plantId visitado/contexto */}
+            {/* Estatísticas da Planta - linkado à última planta visitada, se disponível */}
             <Link
-              to="/plant/ultima/statistics"
+              to={lastPlantId ? `/plant/${lastPlantId}/statistics` : '/plants'}
               className="block px-4 py-3 text-base font-medium text-green-700 rounded-lg hover:bg-green-100 dark:text-green-300 dark:hover:bg-slate-700 transition-colors"
               onClick={onClose}
             >
-              Estatísticas da Planta
+              {lastPlantName ? `Estatísticas de ${lastPlantName}` : 'Estatísticas da Planta'}
             </Link>
             {/* Adicionar outros links conforme necessário */}
             {/* Exemplo: Adicionar Planta, Escanear QR Code - estes já estão no DashboardPage, mas podem ser adicionados aqui também se fizer sentido */}

--- a/pages/PlantDetailPage.tsx
+++ b/pages/PlantDetailPage.tsx
@@ -54,6 +54,19 @@ const PlantDetailPage: React.FC = () => {
   }, [loadPlantData]);
 
   useEffect(() => {
+    if (plantId && typeof window !== 'undefined') {
+      try {
+        localStorage.setItem('lastPlantId', plantId);
+        if (plant && plant.name) {
+          localStorage.setItem('lastPlantName', plant.name);
+        }
+      } catch {
+        // ignore write errors (e.g. private mode)
+      }
+    }
+  }, [plantId, plant]);
+
+  useEffect(() => {
     // Prefixed for Safari, Chrome/Edge support window.SpeechRecognition
     const SpeechRecognitionAPI = (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
     if (!SpeechRecognitionAPI) {
@@ -142,6 +155,17 @@ const PlantDetailPage: React.FC = () => {
       if (res.status === 204) {
         setShowRemoveByDiseaseModal(false);
         setRemoveByDiseaseNote('');
+        try {
+          if (typeof window !== 'undefined') {
+            const lastId = localStorage.getItem('lastPlantId');
+            if (lastId === plantId) {
+              localStorage.removeItem('lastPlantId');
+              localStorage.removeItem('lastPlantName');
+            }
+          }
+        } catch {
+          // ignore
+        }
         window.location.href = '/';
         return;
       } else {


### PR DESCRIPTION
## Summary
- remember last plant name alongside ID
- show the name in the hamburger menu
- clear stored plant info when plant is removed

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683f735e9550832a9e196b02a9108209