### PR TITLE
Integrate Supabase diary entry storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,8 @@ This contains everything you need to run your app locally.
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
    `npm run dev`
+
+## Database Setup
+
+Run the SQL script in `supabase/diary_entries.sql` on your Supabase project to
+create the `diary_entries` table used by the Netlify functions.

--- a/contexts/PlantContext.tsx
+++ b/contexts/PlantContext.tsx
@@ -122,9 +122,27 @@ export const PlantProvider: React.FC<{ children: ReactNode }> = ({ children }) =
     }
   }, []);
 
+  const fetchDiaryEntries = useCallback(async (plantId: string) => {
+    setIsLoading(true);
+    try {
+      const entries = await apiGetDiaryEntriesByPlantId(plantId);
+      setDiaryEntries(prev => ({ ...prev, [plantId]: entries }));
+      setIsLoading(false);
+      return entries;
+    } catch (e) {
+      setError(`Falha ao carregar entradas do diário para planta ${plantId}.`);
+      setIsLoading(false);
+      return [];
+    }
+  }, []);
+
   const getDiaryEntries = useCallback((plantId: string) => {
+    if (!diaryEntries[plantId]) {
+      // Fetch asynchronously if not already loaded
+      fetchDiaryEntries(plantId).catch(() => undefined);
+    }
     return diaryEntries[plantId] || [];
-  }, [diaryEntries]);
+  }, [diaryEntries, fetchDiaryEntries]);
 
   const deletePlant = useCallback(async (plantId: string) => {
     setIsLoading(true);
@@ -140,20 +158,6 @@ export const PlantProvider: React.FC<{ children: ReactNode }> = ({ children }) =
     }
   }, []);
 
-  const fetchDiaryEntries = useCallback(async (plantId: string) => {
-    setIsLoading(true);
-    try {
-      const entries = await apiGetDiaryEntriesByPlantId(plantId);
-      setDiaryEntries(prev => ({ ...prev, [plantId]: entries }));
-      setIsLoading(false);
-      return entries;
-    } catch (e) {
-      setError(`Falha ao carregar entradas do diário para planta ${plantId}.`);
-      setIsLoading(false);
-      return [];
-    }
-  }, []);
-  
   const addNewDiaryEntry = useCallback(async (plantId: string, entryData: NewDiaryEntryData) => {
     setIsLoading(true);
     try {

--- a/netlify/functions/addDiaryEntry.ts
+++ b/netlify/functions/addDiaryEntry.ts
@@ -1,0 +1,52 @@
+import { Handler } from '@netlify/functions';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+
+function camelToSnake(obj: any) {
+  const newObj: any = {};
+  for (const key in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      const snakeKey = key.replace(/[A-Z]/g, (l) => `_${l.toLowerCase()}`);
+      newObj[snakeKey] = obj[key];
+    }
+  }
+  return newObj;
+}
+
+export const handler: Handler = async (event, context) => {
+  const { user } = context.clientContext || {};
+  if (!user || !user.sub) {
+    return { statusCode: 401, body: JSON.stringify({ error: 'Usuário não autenticado.' }) };
+  }
+  const userId = user.sub;
+
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, body: JSON.stringify({ error: 'Método não permitido. Use POST.' }), headers: { Allow: 'POST' } };
+  }
+  if (!event.body) {
+    return { statusCode: 400, body: JSON.stringify({ error: 'Corpo da requisição ausente.' }) };
+  }
+
+  try {
+    const body = JSON.parse(event.body);
+    if (!body.plantId) {
+      return { statusCode: 400, body: JSON.stringify({ error: 'plantId é obrigatório.' }) };
+    }
+    const entry = camelToSnake(body);
+    entry.user_id = userId;
+    delete entry.id;
+
+    const { data, error } = await supabase
+      .from('diary_entries')
+      .insert([entry])
+      .select('*')
+      .single();
+    if (error) {
+      return { statusCode: 500, body: JSON.stringify({ error: 'Erro ao adicionar entrada.', details: error.message }) };
+    }
+    return { statusCode: 201, body: JSON.stringify(data) };
+  } catch (e: any) {
+    return { statusCode: 500, body: JSON.stringify({ error: 'Erro inesperado no servidor.', details: e.message }) };
+  }
+};

--- a/netlify/functions/deleteDiaryEntry.ts
+++ b/netlify/functions/deleteDiaryEntry.ts
@@ -1,0 +1,37 @@
+import { Handler } from '@netlify/functions';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+
+export const handler: Handler = async (event, context) => {
+  const { user } = context.clientContext || {};
+  if (!user || !user.sub) {
+    return { statusCode: 401, body: JSON.stringify({ error: 'Usuário não autenticado.' }) };
+  }
+  const userId = user.sub;
+
+  if (event.httpMethod !== 'DELETE') {
+    return { statusCode: 405, body: JSON.stringify({ error: 'Método não permitido. Use DELETE.' }), headers: { Allow: 'DELETE' } };
+  }
+  const entryId = event.queryStringParameters?.id;
+  if (!entryId) {
+    return { statusCode: 400, body: JSON.stringify({ error: 'Parâmetro id é obrigatório.' }) };
+  }
+
+  try {
+    const { error, count } = await supabase
+      .from('diary_entries')
+      .delete()
+      .eq('id', entryId)
+      .eq('user_id', userId);
+    if (error) {
+      return { statusCode: 500, body: JSON.stringify({ error: 'Erro ao excluir entrada.', details: error.message }) };
+    }
+    if (count === 0) {
+      return { statusCode: 404, body: JSON.stringify({ error: 'Entrada não encontrada.' }) };
+    }
+    return { statusCode: 204, body: '' };
+  } catch (e: any) {
+    return { statusCode: 500, body: JSON.stringify({ error: 'Erro inesperado no servidor.', details: e.message }) };
+  }
+};

--- a/netlify/functions/getDiaryEntries.ts
+++ b/netlify/functions/getDiaryEntries.ts
@@ -1,0 +1,31 @@
+import { Handler } from '@netlify/functions';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+
+export const handler: Handler = async (event, context) => {
+  const { user } = context.clientContext || {};
+  if (!user || !user.sub) {
+    return { statusCode: 401, body: JSON.stringify({ error: 'Usuário não autenticado.' }) };
+  }
+  const userId = user.sub;
+  const plantId = event.queryStringParameters?.plantId;
+  if (!plantId) {
+    return { statusCode: 400, body: JSON.stringify({ error: 'Parâmetro plantId é obrigatório.' }) };
+  }
+
+  try {
+    const { data, error } = await supabase
+      .from('diary_entries')
+      .select('*')
+      .eq('user_id', userId)
+      .eq('plant_id', plantId)
+      .order('timestamp', { ascending: false });
+    if (error) {
+      return { statusCode: 500, body: JSON.stringify({ error: 'Erro ao buscar entradas.', details: error.message }) };
+    }
+    return { statusCode: 200, body: JSON.stringify(data || []) };
+  } catch (e: any) {
+    return { statusCode: 500, body: JSON.stringify({ error: 'Erro inesperado no servidor.', details: e.message }) };
+  }
+};

--- a/netlify/functions/updateDiaryEntry.ts
+++ b/netlify/functions/updateDiaryEntry.ts
@@ -1,0 +1,58 @@
+import { Handler } from '@netlify/functions';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+
+function camelToSnake(obj: any) {
+  const newObj: any = {};
+  for (const key in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      const snakeKey = key.replace(/[A-Z]/g, (l) => `_${l.toLowerCase()}`);
+      newObj[snakeKey] = obj[key];
+    }
+  }
+  return newObj;
+}
+
+export const handler: Handler = async (event, context) => {
+  const { user } = context.clientContext || {};
+  if (!user || !user.sub) {
+    return { statusCode: 401, body: JSON.stringify({ error: 'Usuário não autenticado.' }) };
+  }
+  const userId = user.sub;
+
+  if (event.httpMethod !== 'PUT') {
+    return { statusCode: 405, body: JSON.stringify({ error: 'Método não permitido. Use PUT.' }), headers: { Allow: 'PUT' } };
+  }
+  if (!event.body) {
+    return { statusCode: 400, body: JSON.stringify({ error: 'Corpo da requisição ausente.' }) };
+  }
+
+  try {
+    const body = JSON.parse(event.body);
+    if (!body.id) {
+      return { statusCode: 400, body: JSON.stringify({ error: 'ID da entrada é obrigatório.' }) };
+    }
+    const entryId = body.id;
+    const updateData = camelToSnake(body);
+    delete updateData.id;
+    delete updateData.user_id;
+
+    const { data, error } = await supabase
+      .from('diary_entries')
+      .update({ ...updateData, updated_at: new Date().toISOString() })
+      .eq('id', entryId)
+      .eq('user_id', userId)
+      .select('*')
+      .single();
+    if (error) {
+      return { statusCode: 500, body: JSON.stringify({ error: 'Erro ao atualizar entrada.', details: error.message }) };
+    }
+    if (!data) {
+      return { statusCode: 404, body: JSON.stringify({ error: 'Entrada não encontrada.' }) };
+    }
+    return { statusCode: 200, body: JSON.stringify(data) };
+  } catch (e: any) {
+    return { statusCode: 500, body: JSON.stringify({ error: 'Erro inesperado no servidor.', details: e.message }) };
+  }
+};

--- a/supabase/diary_entries.sql
+++ b/supabase/diary_entries.sql
@@ -1,0 +1,22 @@
+-- SQL schema for diary_entries table
+create table if not exists diary_entries (
+  id uuid primary key default uuid_generate_v4(),
+  plant_id uuid references plants(id) on delete cascade not null,
+  user_id uuid references auth.users(id) not null,
+  timestamp timestamptz not null default now(),
+  author text not null,
+  notes text,
+  stage text,
+  height_cm numeric,
+  ec numeric,
+  ph numeric,
+  temperature numeric,
+  humidity numeric,
+  symptoms text,
+  actions_taken text,
+  photos jsonb,
+  ai_overall_diagnosis text
+);
+
+create index if not exists diary_entries_plant_idx on diary_entries(plant_id);
+create index if not exists diary_entries_user_idx on diary_entries(user_id);


### PR DESCRIPTION
## Summary
- add SQL for `diary_entries` table
- create Netlify Functions for diary entry CRUD
- switch plant service to use the new API instead of localStorage
- fetch diary entries via Supabase in context
- document new DB setup step

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683f76a7e334832a86056bba43742e5e