### PR TITLE
Add basic i18n support

### DIFF
--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: 'primary' | 'secondary' | 'danger' | 'ghost';
@@ -26,6 +27,7 @@ const Button: React.FC<ButtonProps> = ({
   disabled,
   ...props
 }) => {
+  const { t } = useTranslation();
   const base =
     'inline-flex items-center justify-center rounded-full font-semibold transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 shadow-sm';
   const variants: Record<string, string> = {
@@ -64,7 +66,7 @@ const Button: React.FC<ButtonProps> = ({
       {loading ? (
         <span className="flex items-center gap-2">
           <span className="w-4 h-4 border-2 border-white border-t-transparent animate-spin rounded-full" />
-          <span>{typeof children === 'string' ? 'Carregando...' : children}</span>
+          <span>{typeof children === 'string' ? t('loading') : children}</span>
         </span>
       ) : (
         children

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import PlusIcon from './icons/PlusIcon';
 import ProfileDropdown from './ProfileDropdown';
@@ -11,14 +12,15 @@ interface HeaderProps {
   onOpenScannerModal: () => void;
 }
 
-const Header: React.FC<HeaderProps> = ({ 
-  title, 
-  onOpenSidebar, 
+const Header: React.FC<HeaderProps> = ({
+  title,
+  onOpenSidebar,
   onOpenAddModal,
   onOpenScannerModal
 }) => {
   const { user, logout } = useAuth(); // Ensure logout is extracted
   const [isProfileDropdownOpen, setIsProfileDropdownOpen] = useState(false);
+  const { t } = useTranslation();
 
   console.log('[Header.tsx] Rendering. User:', user, 'isProfileDropdownOpen:', isProfileDropdownOpen);
 
@@ -34,10 +36,10 @@ const Header: React.FC<HeaderProps> = ({
       <div className="flex items-center justify-between">
         {/* Left: Menu + Title */}
         <div className="flex items-center space-x-4">
-          <button 
-            className="md:hidden text-gray-400 hover:text-white" 
+          <button
+            className="md:hidden text-gray-400 hover:text-white"
             onClick={onOpenSidebar}
-            aria-label="Abrir menu"
+            aria-label={t('header.open_menu')}
           >
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6">
               <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
@@ -50,11 +52,11 @@ const Header: React.FC<HeaderProps> = ({
         <div className="flex items-center space-x-2">
           {/* Search */}
           <div className="hidden md:block relative">
-            <input
-              type="text"
-              placeholder="Buscar plantas..."
-              className="bg-gray-800 text-gray-200 pl-10 pr-4 py-2 rounded-lg text-sm w-48 focus:w-60 transition-all focus:outline-none focus:ring-2 focus:ring-emerald-500"
-            />
+          <input
+            type="text"
+            placeholder={t('header.search')}
+            className="bg-gray-800 text-gray-200 pl-10 pr-4 py-2 rounded-lg text-sm w-48 focus:w-60 transition-all focus:outline-none focus:ring-2 focus:ring-emerald-500"
+          />
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" 
               className="w-5 h-5 text-gray-400 absolute left-3 top-1/2 transform -translate-y-1/2">
               <path strokeLinecap="round" strokeLinejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
@@ -65,7 +67,7 @@ const Header: React.FC<HeaderProps> = ({
           <button
             onClick={onOpenScannerModal}
             className="bg-purple-600 hover:bg-purple-700 text-white p-2 rounded-lg transition-colors"
-            aria-label="Escanear QR"
+            aria-label={t('header.scan_qr')}
           >
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5">
               <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 4.875c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5A1.125 1.125 0 0 1 3.75 9.375v-4.5ZM3.75 14.625c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5a1.125 1.125 0 0 1-1.125-1.125v-4.5ZM13.5 4.875c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5A1.125 1.125 0 0 1 13.5 9.375v-4.5Z" />
@@ -76,10 +78,10 @@ const Header: React.FC<HeaderProps> = ({
           <button
             onClick={onOpenAddModal}
             className="bg-emerald-600 hover:bg-emerald-700 text-white p-2 rounded-lg transition-colors flex items-center space-x-1"
-            aria-label="Adicionar planta"
+            aria-label={t('header.add_plant')}
           >
-            <PlusIcon className="w-5 h-5" />
-            <span className="hidden md:inline">Adicionar Planta</span>
+           <PlusIcon className="w-5 h-5" />
+            <span className="hidden md:inline">{t('header.add_plant')}</span>
           </button>
           
           {/* Notification */}
@@ -123,7 +125,7 @@ const Header: React.FC<HeaderProps> = ({
         <div className="relative">
           <input
             type="text"
-            placeholder="Buscar plantas..."
+            placeholder={t('header.search')}
             className="bg-gray-800 text-gray-200 pl-10 pr-4 py-2 rounded-lg text-sm w-full focus:outline-none focus:ring-2 focus:ring-emerald-500"
           />
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" 

--- a/components/ProfileDropdown.tsx
+++ b/components/ProfileDropdown.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { User } from 'netlify-identity-widget'; // Assuming User type is available from this import
 
 interface ProfileDropdownProps {
@@ -11,6 +12,7 @@ interface ProfileDropdownProps {
 
 const ProfileDropdown: React.FC<ProfileDropdownProps> = ({ isOpen, onClose, onLogout, user }) => {
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const { t, i18n } = useTranslation();
 
   // Effect to handle clicks outside the dropdown to close it
   useEffect(() => {
@@ -50,7 +52,7 @@ const ProfileDropdown: React.FC<ProfileDropdownProps> = ({ isOpen, onClose, onLo
         role="menuitem"
         onClick={onClose} // Also close dropdown when a link is clicked
       >
-        Meu Perfil
+        {t('profile.my_profile')}
       </Link>
       <button
         onClick={() => {
@@ -60,7 +62,21 @@ const ProfileDropdown: React.FC<ProfileDropdownProps> = ({ isOpen, onClose, onLo
         className="block px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white w-full text-left"
         role="menuitem"
       >
-        Sair
+        {t('profile.logout')}
+      </button>
+      <div className="border-t border-gray-700 my-1"></div>
+      <div className="px-4 py-1 text-xs text-gray-400">{t('profile.language')}</div>
+      <button
+        onClick={() => i18n.changeLanguage('en')}
+        className="block px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white w-full text-left"
+      >
+        {t('language.english')}
+      </button>
+      <button
+        onClick={() => i18n.changeLanguage('pt')}
+        className="block px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white w-full text-left"
+      >
+        {t('language.portuguese')}
       </button>
     </div>
   );

--- a/components/QuickActions.tsx
+++ b/components/QuickActions.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 interface QuickActionProps {
   title: string;
@@ -34,16 +35,17 @@ interface QuickActionsProps {
   onOpenStats: () => void;
 }
 
-const QuickActions: React.FC<QuickActionsProps> = ({ 
-  onAddPlant, 
+const QuickActions: React.FC<QuickActionsProps> = ({
+  onAddPlant,
   onScanQR,
   onOpenCultivos,
   onOpenStats
 }) => {
+  const { t } = useTranslation();
   return (
     <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
       <QuickAction
-        title="Adicionar Planta"
+        title={t('header.add_plant')}
         icon={
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-8 h-8">
             <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
@@ -53,7 +55,7 @@ const QuickActions: React.FC<QuickActionsProps> = ({
         onClick={onAddPlant}
       />
       <QuickAction
-        title="Scanner QR"
+        title={t('sidebar.scanner')}
         icon={
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-8 h-8">
             <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 4.875c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5A1.125 1.125 0 0 1 3.75 9.375v-4.5ZM3.75 14.625c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5a1.125 1.125 0 0 1-1.125-1.125v-4.5ZM13.5 4.875c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5A1.125 1.125 0 0 1 13.5 9.375v-4.5Z" />
@@ -63,7 +65,7 @@ const QuickActions: React.FC<QuickActionsProps> = ({
         onClick={onScanQR}
       />
       <QuickAction
-        title="Cultivos"
+        title={t('sidebar.cultivos')}
         icon={
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-8 h-8">
             <path strokeLinecap="round" strokeLinejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" />
@@ -73,7 +75,7 @@ const QuickActions: React.FC<QuickActionsProps> = ({
         onClick={onOpenCultivos}
       />
       <QuickAction
-        title="Estatísticas"
+        title={t('sidebar.statistics')}
         icon={
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-8 h-8">
             <path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
+import { useTranslation } from 'react-i18next';
 
 // Icons
 import LeafIcon from './icons/LeafIcon';
@@ -13,6 +14,7 @@ interface SidebarProps {
 const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose }) => {
   const location = useLocation();
   const { user } = useAuth();
+  const { t } = useTranslation();
 
   const displayName = user?.user_metadata?.full_name || user?.email || 'Usuário';
   let initials = 'U'; // Default to 'U' for Usuário
@@ -24,28 +26,28 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose }) => {
   
   // Define navigation items with icons
   const navItems = [
-    { name: 'Dashboard', path: '/', icon: (
+    { name: t('sidebar.dashboard'), path: '/', icon: (
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5">
         <path strokeLinecap="round" strokeLinejoin="round" d="M3 8.25V18a2.25 2.25 0 0 0 2.25 2.25h13.5A2.25 2.25 0 0 0 21 18V8.25m-18 0V6a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 6v2.25m-18 0h18M5.25 6h.008v.008H5.25V6Z" />
       </svg>
     ) },
-    { name: 'Plantas', path: '/plants', icon: <LeafIcon className="w-5 h-5" /> },
-    { name: 'Cultivos', path: '/cultivos', icon: (
+    { name: t('sidebar.plants'), path: '/plants', icon: <LeafIcon className="w-5 h-5" /> },
+    { name: t('sidebar.cultivos'), path: '/cultivos', icon: (
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5">
         <path strokeLinecap="round" strokeLinejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" />
       </svg>
     ) },
-    { name: 'Scanner QR', path: '/scanner', icon: (
+    { name: t('sidebar.scanner'), path: '/scanner', icon: (
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5">
         <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 4.875c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5A1.125 1.125 0 0 1 3.75 9.375v-4.5ZM3.75 14.625c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5a1.125 1.125 0 0 1-1.125-1.125v-4.5ZM13.5 4.875c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5A1.125 1.125 0 0 1 13.5 9.375v-4.5Z" />
       </svg>
     ) },
-    { name: 'Estatísticas', path: '/statistics', icon: (
+    { name: t('sidebar.statistics'), path: '/statistics', icon: (
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5">
         <path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />
       </svg>
     ) },
-    { name: 'Configurações', path: '/settings', icon: (
+    { name: t('sidebar.settings'), path: '/settings', icon: (
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5">
         <path strokeLinecap="round" strokeLinejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z" />
         <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />

--- a/i18n.ts
+++ b/i18n.ts
@@ -1,0 +1,21 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+import en from './locales/en/translation.json';
+import pt from './locales/pt/translation.json';
+
+i18n
+  .use(initReactI18next)
+  .init({
+    resources: {
+      en: { translation: en },
+      pt: { translation: pt },
+    },
+    lng: 'pt',
+    fallbackLng: 'en',
+    interpolation: {
+      escapeValue: false,
+    },
+  });
+
+export default i18n;

--- a/index.tsx
+++ b/index.tsx
@@ -4,6 +4,7 @@ import App from './App';
 import { BrowserRouter } from 'react-router-dom';
 import { ThemeProvider } from './contexts/ThemeContext';
 import { AuthProvider } from './contexts/AuthContext';
+import './i18n';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -1,0 +1,26 @@
+{
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "plants": "Plants",
+    "cultivos": "Cultivos",
+    "scanner": "QR Scanner",
+    "statistics": "Statistics",
+    "settings": "Settings"
+  },
+  "profile": {
+    "my_profile": "My Profile",
+    "logout": "Logout",
+    "language": "Language"
+  },
+  "header": {
+    "search": "Search plants...",
+    "open_menu": "Open menu",
+    "scan_qr": "Scan QR",
+    "add_plant": "Add Plant"
+  },
+  "language": {
+    "english": "English",
+    "portuguese": "Portuguese"
+  },
+  "loading": "Loading..."
+}

--- a/locales/pt/translation.json
+++ b/locales/pt/translation.json
@@ -1,0 +1,26 @@
+{
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "plants": "Plantas",
+    "cultivos": "Cultivos",
+    "scanner": "Scanner QR",
+    "statistics": "Estatísticas",
+    "settings": "Configurações"
+  },
+  "profile": {
+    "my_profile": "Meu Perfil",
+    "logout": "Sair",
+    "language": "Idioma"
+  },
+  "header": {
+    "search": "Buscar plantas...",
+    "open_menu": "Abrir menu",
+    "scan_qr": "Escanear QR",
+    "add_plant": "Adicionar Planta"
+  },
+  "language": {
+    "english": "Inglês",
+    "portuguese": "Português"
+  },
+  "loading": "Carregando..."
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,14 @@
       "dependencies": {
         "@supabase/supabase-js": "^2.49.8",
         "@yudiel/react-qr-scanner": "^2.3.1",
+        "i18next": "^25.2.1",
         "jspdf": "^3.0.1",
         "netlify-identity-widget": "^1.9.2",
         "qrcode": "^1.5.4",
         "qrcode.react": "^3.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-i18next": "^15.5.2",
         "react-router-dom": "^7.6.1"
       },
       "devDependencies": {
@@ -5626,6 +5628,15 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/html2canvas": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
@@ -5659,6 +5670,37 @@
       "dev": true,
       "engines": {
         "node": ">=16.17.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.2.1",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.2.1.tgz",
+      "integrity": "sha512-+UoXK5wh+VlE1Zy5p6MjcvctHXAhRwQKCxiJD8noKZzIXmnAX8gdHX5fLPA3MEVxEN4vbZkQFy8N0LyD9tUqPw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.1"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/ieee754": {
@@ -22572,6 +22614,32 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.5.2.tgz",
+      "integrity": "sha512-ePODyXgmZQAOYTbZXQn5rRsSBu3Gszo69jxW6aKmlSgxKAI1fOhDwSu6bT4EKHciWPKQ7v7lPrjeiadR6Gi+1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.0",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.2.3",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -23722,7 +23790,7 @@
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -23945,6 +24013,15 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/web-streams-polyfill": {

--- a/package.json
+++ b/package.json
@@ -11,12 +11,14 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.49.8",
     "@yudiel/react-qr-scanner": "^2.3.1",
+    "i18next": "^25.2.1",
     "jspdf": "^3.0.1",
     "netlify-identity-widget": "^1.9.2",
     "qrcode": "^1.5.4",
     "qrcode.react": "^3.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-i18next": "^15.5.2",
     "react-router-dom": "^7.6.1"
   },
   "devDependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,8 @@
     "noEmit": true,
     "allowJs": true,
     "jsx": "react-jsx",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
 
     /* Linting */
     "strict": true,


### PR DESCRIPTION
## Summary
- integrate i18next with English and Portuguese translations
- add language switcher under profile dropdown
- translate navigation labels, header actions, buttons
- enable JSON modules in tsconfig

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683f75a69260832abd3ac3d108089888