### PR TITLE
Integrate real AI diagnosis and improve plant detail responsiveness

### DIFF
--- a/components/DiaryEntryForm.tsx
+++ b/components/DiaryEntryForm.tsx
@@ -2,7 +2,7 @@ import React, { useState, ChangeEvent, FormEvent, useEffect } from 'react';
 import { DiaryEntry, PlantStage, Photo, NewPhoto, NewDiaryEntryData } from '../types'; // Import centralized types
 import { PLANT_STAGES_OPTIONS, DEFAULT_AI_PROMPT } from '../constants';
 import ImageUpload from './ImageUpload';
-import { getMockImageDiagnosis } from '../services/geminiService'; // Using the mock Gemini service
+import { getImageDiagnosis } from '../services/geminiService';
 import LoadingSpinner from './LoadingSpinner';
 import Button from './Button';
 
@@ -57,7 +57,7 @@ const DiaryEntryForm: React.FC<DiaryEntryFormProps> = ({ plantCurrentStage, onSu
     setIsDiagnosing(true);
     setDiagnosisError(null);
     try {
-        const diagnosis = await getMockImageDiagnosis(base64, DEFAULT_AI_PROMPT);
+        const diagnosis = await getImageDiagnosis(base64, DEFAULT_AI_PROMPT);
         setUploadedPhotos(prevPhotos => prevPhotos.map(p => 
             p.urlOriginal === base64 ? { ...p, aiSummary: diagnosis.summary, aiRawJson: diagnosis.rawJson } : p
         ));

--- a/netlify/functions/diagnoseImage.ts
+++ b/netlify/functions/diagnoseImage.ts
@@ -1,0 +1,31 @@
+import { Handler } from '@netlify/functions';
+import { GoogleGenerativeAI } from '@google/generative-ai';
+import { DEFAULT_AI_PROMPT } from '../../constants';
+
+const apiKey = process.env.GEMINI_API_KEY || '';
+const ai = apiKey ? new GoogleGenerativeAI(apiKey) : null;
+
+export const handler: Handler = async (event) => {
+  if (!ai) {
+    return { statusCode: 500, body: JSON.stringify({ error: 'API key not configured' }) };
+  }
+  try {
+    const { imageBase64, prompt } = JSON.parse(event.body || '{}');
+    if (!imageBase64) {
+      return { statusCode: 400, body: JSON.stringify({ error: 'Missing imageBase64' }) };
+    }
+    const model = ai.getGenerativeModel({ model: 'gemini-pro-vision' });
+    const result = await model.generateContent([
+      { text: prompt || DEFAULT_AI_PROMPT },
+      { inlineData: { data: imageBase64, mimeType: 'image/jpeg' } },
+    ]);
+    const text = result.response.text();
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ summary: text, rawJson: JSON.stringify(result.response) }),
+    };
+  } catch (error) {
+    console.error('diagnoseImage error', error);
+    return { statusCode: 500, body: JSON.stringify({ error: 'Failed to get diagnosis' }) };
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "buddyscan",
       "version": "0.0.0",
       "dependencies": {
+        "@google/generative-ai": "^0.24.1",
         "@supabase/supabase-js": "^2.49.8",
         "@yudiel/react-qr-scanner": "^2.3.1",
         "i18next": "^25.2.1",
@@ -947,6 +948,15 @@
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.1.1.tgz",
       "integrity": "sha512-5DGmA8FTdB2XbDeEwc/5ZXBl6UbBAyBOOLlPuBnZ/N1SwdH9Ii+cOX3tBROlDgcTXxjOYnLMVoKk9+FXAw0CJw==",
       "dev": true
+    },
+    "node_modules/@google/generative-ai": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
+      "integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@google/generative-ai": "^0.24.1",
     "@supabase/supabase-js": "^2.49.8",
     "@yudiel/react-qr-scanner": "^2.3.1",
     "i18next": "^25.2.1",

--- a/pages/PlantDetailPage.tsx
+++ b/pages/PlantDetailPage.tsx
@@ -488,7 +488,7 @@ const PlantDetailPage: React.FC = () => {
                     <span className="text-sm text-gray-500 dark:text-gray-400">•</span>
                     <span className="text-sm text-gray-500 dark:text-gray-400">ID: {plant ? plant.id : ''}</span>
                   </div>
-                  <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-2 text-sm">
                     <div className="flex flex-col">
                       <span className="text-gray-500 dark:text-gray-400">Strain</span>
                       <span className="font-medium text-gray-900 dark:text-white">{plant.strain || 'N/A'}</span>

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -1,85 +1,21 @@
-
-// This is a MOCK service. In a real application, this would interact with the GoogleGenAI SDK.
-// For example, `import { GoogleGenAI } from "@google/genai";` would be used.
-// The API key would be `process.env.API_KEY`, handled by the backend or a secure environment.
-
 import { DEFAULT_AI_PROMPT } from '../constants';
 
-/**
- * Simulates getting an AI diagnosis for an image.
- * In a real app, imageBase64 would be sent to the Gemini API.
- * @param imageBase64 The base64 encoded string of the image.
- * @param prompt Optional prompt to guide the AI.
- * @returns A promise that resolves to a mock diagnosis.
- */
-export const getMockImageDiagnosis = async (
-   
-  imageBase64: string, 
+export interface ImageDiagnosisResult {
+  summary: string;
+  rawJson?: string;
+}
+
+export const getImageDiagnosis = async (
+  imageBase64: string,
   prompt: string = DEFAULT_AI_PROMPT
-): Promise<{ summary: string; rawJson: string }> => {
-  // Simulate API call delay
-  await new Promise(resolve => setTimeout(resolve, 1500 + Math.random() * 1000));
-
-  const diagnoses = [
-    "Folhas com pontas queimadas e curvadas para cima, possível excesso de nutrientes (nutrient burn). Recomenda-se flush com água pura.",
-    "Manchas amarelas internervais nas folhas mais velhas, progredindo para cima. Pode ser deficiência de Magnésio. Considerar suplementação com CalMag.",
-    "Pequenos pontos brancos e teias finas sob as folhas. Suspeita de infestação por spider mites. Tratar com óleo de neem ou sabão inseticida.",
-    "Mofo cinza e pulverulento formando-se nos botões e folhas. Alerta para Botrytis (mofo cinzento). Aumentar ventilação e reduzir umidade.",
-    "Planta parece saudável e vigorosa, com coloração verde escura uniforme. Nenhum sinal aparente de pragas ou deficiências.",
-    "Folhas inferiores amareladas e caindo, enquanto o crescimento novo parece saudável. Pode ser deficiência de Nitrogênio, comum no início da floração.",
-    "Crescimento lento e entrenós muito curtos. Verificar pH da rega e do solo, pode estar fora da faixa ideal.",
-    "Manchas marrons ou necróticas com halos amarelos. Pode ser uma doença fúngica como Septoria. Remover folhas afetadas e melhorar circulação de ar."
-  ];
-  
-  const randomDiagnosis = diagnoses[Math.floor(Math.random() * diagnoses.length)];
-
-  return {
-    summary: `${randomDiagnosis}`, // Prompt is already part of typical diagnosis structure here
-    rawJson: JSON.stringify({
-      details: "Esta é uma análise simulada pela IA. Em um cenário real, conteria dados estruturados da resposta do modelo Gemini.",
-      confidence: parseFloat((Math.random() * 0.3 + 0.7).toFixed(2)), // between 0.7 and 1.0
-      observedFeatures: ["folhas", "coloração", "textura"],
-      potentialIssues: prompt.toLowerCase().includes("deficiência") ? ["deficiência nutricional"] : ["geral"],
-      recommendations: ["Monitorar de perto", "Ajustar rega se necessário"],
-      timestamp: new Date().toISOString(),
-      modelUsed: "gemini-2.5-flash-preview-04-17 (simulado)",
-    }),
-  };
-};
-
-// Example of how a real Gemini API call might look (conceptual, not for direct use here as it needs API key and setup)
-/*
-import { GoogleGenAI, GenerateContentResponse } from "@google/genai";
-
-// This would typically be in a backend service or secure environment
-// const API_KEY = process.env.API_KEY; 
-// if (!API_KEY) throw new Error("API_KEY not found");
-// const ai = new GoogleGenAI({ apiKey: API_KEY });
-
-export const getRealImageDiagnosis = async (imageBase64: string, mimeType: string, userPrompt: string): Promise<string> => {
-  try {
-    const imagePart = {
-      inlineData: {
-        mimeType: mimeType, // e.g., 'image/jpeg' or 'image/png'
-        data: imageBase64,
-      },
-    };
-    const textPart = { text: userPrompt };
-
-    const response: GenerateContentResponse = await ai.models.generateContent({
-        model: 'gemini-2.5-flash-preview-04-17', // or other suitable vision model
-        contents: { parts: [imagePart, textPart] },
-    });
-    
-    // The actual text response from Gemini.
-    // Needs robust error handling and parsing in a real app.
-    return response.text;
-
-  } catch (error) {
-    console.error("Error calling Gemini API:", error);
-    // Handle different types of errors, e.g. GoogleGenAIError
-    // if (error instanceof GoogleGenAIError) { ... }
-    throw new Error("Failed to get diagnosis from Gemini API.");
+): Promise<ImageDiagnosisResult> => {
+  const res = await fetch('/.netlify/functions/diagnoseImage', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ imageBase64, prompt }),
+  });
+  if (!res.ok) {
+    throw new Error(`Diagnose API error: ${res.status}`);
   }
+  return res.json();
 };
-*/


### PR DESCRIPTION
## Summary
- add Google generative AI dependency
- create Netlify function `diagnoseImage` to call Gemini
- add client service `getImageDiagnosis` and use it in diary form
- fix plant detail info grid responsiveness

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683f79ae8ad4832a87d7d5ba3d473898