### PR TITLE
Add bulk plant move feature

### DIFF
--- a/components/PlantCard.tsx
+++ b/components/PlantCard.tsx
@@ -4,12 +4,15 @@ import { Plant } from '../types';
 interface PlantCardProps {
   plant: Plant;
   onClick?: () => void;
+  selectable?: boolean;
+  selected?: boolean;
+  onSelectToggle?: () => void;
 }
 
 // import { usePlantContext } from '../contexts/PlantContext'; // Removed as updatePlantDetails is no longer used
 // import { PlantOperationalStatus } from '../types'; // Removed as it's no longer used
 
-const PlantCard: React.FC<PlantCardProps> = ({ plant, onClick }) => {
+const PlantCard: React.FC<PlantCardProps> = ({ plant, onClick, selectable, selected, onSelectToggle }) => {
 
   // const { updatePlantDetails } = usePlantContext(); // Removed
   // const [isMarkingLost, setIsMarkingLost] = React.useState(false); // Removed
@@ -33,11 +36,21 @@ const PlantCard: React.FC<PlantCardProps> = ({ plant, onClick }) => {
   //   }
   // };
 
+  const handleClick = () => {
+    if (selectable) {
+      onSelectToggle && onSelectToggle();
+    } else if (onClick) {
+      onClick();
+    } else {
+      window.location.href = `/plant/${plant.id}`;
+    }
+  };
+
   return (
     <div className="relative group">
       <div
-        onClick={onClick ? onClick : () => window.location.href = `/plant/${plant.id}`}
-        className="cursor-pointer block relative rounded-3xl shadow-xl hover:shadow-green-300/40 dark:hover:shadow-green-500/30 transition-all duration-300 overflow-hidden group hover:-translate-y-2 focus:outline-none focus:ring-2 focus:ring-green-400 focus:ring-opacity-40 bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700"
+        onClick={handleClick}
+        className={`cursor-pointer block relative rounded-3xl shadow-xl hover:shadow-green-300/40 dark:hover:shadow-green-500/30 transition-all duration-300 overflow-hidden group hover:-translate-y-2 focus:outline-none focus:ring-2 focus:ring-green-400 focus:ring-opacity-40 bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 ${selectable && selected ? 'ring-4 ring-emerald-500/70' : ''}`}
         style={{
           minHeight: 320,
         }}
@@ -63,6 +76,24 @@ const PlantCard: React.FC<PlantCardProps> = ({ plant, onClick }) => {
         </div>
         {/* Sombra decorativa inferior */}
         <div className="absolute bottom-0 left-0 w-full h-10 bg-gradient-to-t from-green-100/60 to-transparent dark:from-slate-800/60 pointer-events-none" />
+        {selectable && (
+          <div className="absolute top-2 right-2">
+            <div className={`w-6 h-6 rounded-full border-2 flex items-center justify-center ${selected ? 'bg-emerald-500 border-emerald-600 text-white' : 'bg-white/70 border-gray-300 text-transparent'}`}>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                className="w-4 h-4"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M9.53 16.28a.75.75 0 0 1-1.06 0l-3.25-3.25a.75.75 0 1 1 1.06-1.06l2.72 2.72 6.72-6.72a.75.75 0 0 1 1.06 1.06l-7.25 7.25z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </div>
+          </div>
+        )}
       </div>
 
       {/* Botão de ação rápida para remover por doença - REMOVED */}


### PR DESCRIPTION
## Summary
- allow selecting multiple plants in AllPlantsPage
- show overlay checkbox on PlantCard when selectable
- move selected plants to an existing cultivo via bottom action bar

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684086624b74832a9b0ccba7bb2c4924