### PR TITLE
Refactor cultivation pages

### DIFF
--- a/netlify/functions/addCultivo.ts
+++ b/netlify/functions/addCultivo.ts
@@ -15,8 +15,8 @@ export const handler: Handler = async (event: HandlerEvent, _context: HandlerCon
 
   try {
     const { name, startDate, notes, userId, plants } = JSON.parse(event.body || '{}');
-    if (!name || !startDate || !userId || !Array.isArray(plants) || plants.length === 0) {
-      console.log('[addCultivo] Missing required fields:', { name, startDate, userId, plants });
+    if (!name || !startDate || !userId) {
+      console.log('[addCultivo] Missing required fields:', { name, startDate, userId });
       return {
         statusCode: 400,
         body: JSON.stringify({ error: 'Missing required fields.' })
@@ -37,33 +37,37 @@ export const handler: Handler = async (event: HandlerEvent, _context: HandlerCon
       };
     }
 
-    // 2. Criar as plantas associadas
-    // Corrige automaticamente o campo 'nome' para 'name' se vier do frontend
-    // Converte campos camelCase para snake_case para compatibilidade com o banco
-    const plantsToInsert = plants.map((plant: any) => {
-      const { nome, birthDate, currentStage, healthStatus, operationalStatus, ...rest } = plant;
-      return {
-        ...rest,
-        name: plant.name || nome, // Usa 'name' se existir, senão usa 'nome'
-        birth_date: birthDate,
-        current_stage: currentStage,
-        health_status: healthStatus,
-        operational_status: operationalStatus,
-        cultivo_id: cultivo.id,
-        user_id: userId,
-      };
-    });
-    console.log('[addCultivo] Plants to insert:', plantsToInsert);
-    const { data: createdPlants, error: plantsError } = await supabase
-      .from('plants')
-      .insert(plantsToInsert)
-      .select();
-    console.log('[addCultivo] Plants insert result:', { createdPlants, plantsError });
-    if (plantsError) {
-      return {
-        statusCode: 500,
-        body: JSON.stringify({ error: 'Erro ao criar plantas', details: plantsError })
-      };
+    let createdPlants = [];
+    if (Array.isArray(plants) && plants.length > 0) {
+      // 2. Criar as plantas associadas
+      // Corrige automaticamente o campo 'nome' para 'name' se vier do frontend
+      // Converte campos camelCase para snake_case para compatibilidade com o banco
+      const plantsToInsert = plants.map((plant: any) => {
+        const { nome, birthDate, currentStage, healthStatus, operationalStatus, ...rest } = plant;
+        return {
+          ...rest,
+          name: plant.name || nome, // Usa 'name' se existir, senão usa 'nome'
+          birth_date: birthDate,
+          current_stage: currentStage,
+          health_status: healthStatus,
+          operational_status: operationalStatus,
+          cultivo_id: cultivo.id,
+          user_id: userId,
+        };
+      });
+      console.log('[addCultivo] Plants to insert:', plantsToInsert);
+      const { data: plantsResult, error: plantsError } = await supabase
+        .from('plants')
+        .insert(plantsToInsert)
+        .select();
+      console.log('[addCultivo] Plants insert result:', { plantsResult, plantsError });
+      if (plantsError) {
+        return {
+          statusCode: 500,
+          body: JSON.stringify({ error: 'Erro ao criar plantas', details: plantsError })
+        };
+      }
+      createdPlants = plantsResult || [];
     }
 
     console.log('[addCultivo] Success:', { cultivo, createdPlants });

--- a/pages/CultivosPage.tsx
+++ b/pages/CultivosPage.tsx
@@ -52,6 +52,8 @@ const CultivosPage: React.FC = () => {
     </div>
   );
 
+  const hasCultivos = cultivos.length > 0;
+
   return (
     <div className="max-w-lg mx-auto w-full p-2 sm:p-4 min-h-screen flex flex-col gap-3 bg-white dark:bg-slate-900">
       {/* Toast global */}
@@ -79,11 +81,13 @@ const CultivosPage: React.FC = () => {
         </Link>
       </div>
 
+      <h1 className="text-2xl font-extrabold text-green-700 dark:text-green-300 mt-4 mb-2">
+        {hasCultivos ? `Meus Cultivos (${cultivos.length})` : 'Meus Cultivos'}
+      </h1>
+
       {/* Lista de cultivos */}
       <div className="mt-2">
-        {cultivos.length === 0 ? (
-          <div className="text-gray-400 dark:text-gray-500 text-center py-8">Nenhum cultivo cadastrado ainda.</div>
-        ) : (
+        {hasCultivos ? (
           <div className="grid grid-cols-1 gap-3">
             {cultivos.map((cultivo) => (
               <Link to={`/cultivo/${cultivo.id}`} key={cultivo.id} className="block group">
@@ -98,6 +102,11 @@ const CultivosPage: React.FC = () => {
                 </div>
               </Link>
             ))}
+          </div>
+        ) : (
+          <div className="text-gray-400 dark:text-gray-500 text-center py-8">
+            Nenhum cultivo cadastrado ainda.<br />
+            <Link to="/novo-cultivo" className="underline text-green-700 dark:text-green-300">Crie seu primeiro cultivo</Link>
           </div>
         )}
       </div>

--- a/pages/NovoCultivoPage.tsx
+++ b/pages/NovoCultivoPage.tsx
@@ -4,50 +4,27 @@ import Button from '../components/Button';
 import ArrowLeftIcon from '../components/icons/ArrowLeftIcon';
 import Toast from '../components/Toast';
 
-interface NovaPlantaForm {
-  name: string;
-  strain: string;
-  birthDate: string;
-}
-
 export default function NovoCultivoPage() {
   const [cultivoNome, setCultivoNome] = useState('');
   const [startDate, setStartDate] = useState('');
   const [notes, setNotes] = useState('');
-  const [plantas, setPlantas] = useState<NovaPlantaForm[]>([]);
-  const [novaPlanta, setNovaPlanta] = useState<NovaPlantaForm>({ name: '', strain: '', birthDate: '' });
   const [saving, setSaving] = useState(false);
   const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' | 'info' } | null>(null);
   const navigate = useNavigate();
-
-  function adicionarPlanta() {
-    if (novaPlanta.name && novaPlanta.strain && novaPlanta.birthDate) {
-      setPlantas([...plantas, novaPlanta]);
-      setNovaPlanta({ name: '', strain: '', birthDate: '' }); // Reset form
-    }
-  }
 
   async function handleSalvarCultivo(e: React.FormEvent) {
     e.preventDefault();
     setSaving(true);
     try {
       const { addCultivo } = await import('../services/cultivoService');
-      // Importar enums dinamicamente para evitar problemas de importação circular
-      const { PlantStage, PlantHealthStatus, PlantOperationalStatus } = await import('../types');
       const cultivoData = {
         name: cultivoNome,
         startDate,
         notes,
-        plants: plantas.map(p => ({
-          ...p,
-          currentStage: PlantStage.SEEDLING,
-          healthStatus: PlantHealthStatus.HEALTHY,
-          operationalStatus: PlantOperationalStatus.ACTIVE,
-        })),
       };
       await addCultivo(cultivoData);
       setSaving(false);
-      setToast({ message: 'Cultivo e plantas criados com sucesso!', type: 'success' });
+      setToast({ message: 'Cultivo criado com sucesso!', type: 'success' });
       setTimeout(() => navigate('/cultivos'), 1800);
     } catch (err: any) {
       setSaving(false);
@@ -102,50 +79,9 @@ export default function NovoCultivoPage() {
             </div>
           </fieldset>
 
-          {/* Adicionar Plantas */}
-          <fieldset className="space-y-4 p-4 border border-gray-200 dark:border-gray-700 rounded-md">
-            <legend className="text-lg font-semibold text-gray-700 dark:text-gray-300 px-2">Adicionar Plantas</legend>
-            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 items-end">
-              <div>
-                <label htmlFor="plantaNome" className={labelStyle}>Nome da Planta</label>
-                <input id="plantaNome" type="text" className={inputStyle} placeholder="Ex: Blueberry OG #1" value={novaPlanta.name} onChange={e => setNovaPlanta({ ...novaPlanta, name: e.target.value })} />
-              </div>
-              <div>
-                <label htmlFor="plantaStrain" className={labelStyle}>Strain</label>
-                <input id="plantaStrain" type="text" className={inputStyle} placeholder="Ex: Blueberry OG" value={novaPlanta.strain} onChange={e => setNovaPlanta({ ...novaPlanta, strain: e.target.value })} />
-              </div>
-              <div>
-                <label htmlFor="plantaNascimento" className={labelStyle}>Nascimento</label>
-                <input id="plantaNascimento" type="date" className={inputStyle} value={novaPlanta.birthDate} onChange={e => setNovaPlanta({ ...novaPlanta, birthDate: e.target.value })} />
-              </div>
-            </div>
-            <div className="flex justify-end mt-2">
-              <Button type="button" variant="secondary" onClick={adicionarPlanta} disabled={!novaPlanta.name || !novaPlanta.strain || !novaPlanta.birthDate}>
-                Adicionar Planta à Lista
-              </Button>
-            </div>
-          </fieldset>
-
-          {/* Lista de Plantas Adicionadas */}
-          {plantas.length > 0 && (
-            <div className="mt-6">
-              <h2 className="text-lg font-semibold text-gray-700 dark:text-gray-300 mb-3">Plantas a Serem Criadas:</h2>
-              <ul className="space-y-2">
-                {plantas.map((p, idx) => (
-                  <li key={idx} className="bg-gray-100 dark:bg-gray-700 p-3 rounded-md shadow-sm flex justify-between items-center">
-                    <div>
-                      <span className="font-medium text-gray-800 dark:text-gray-100">{p.name}</span>
-                      <span className="text-sm text-gray-600 dark:text-gray-300"> ({p.strain}) - Nasc: {new Date(p.birthDate + 'T00:00:00').toLocaleDateString()}</span>
-                    </div>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-
           <div className="mt-8 flex justify-center">
-            <Button type="submit" variant="primary" size="lg" loading={saving} disabled={plantas.length === 0 || !cultivoNome || !startDate}>
-              Salvar Cultivo e Plantas
+            <Button type="submit" variant="primary" size="lg" loading={saving} disabled={!cultivoNome || !startDate}>
+              Salvar Cultivo
             </Button>
           </div>
         </form>

--- a/services/cultivoService.ts
+++ b/services/cultivoService.ts
@@ -81,7 +81,7 @@ const fetchWithAuth = async (endpoint: string, options: RequestInit = {}) => {
   }
 };
 
-export const addCultivo = async (cultivoData: { name: string; startDate: string; notes?: string; plants: Omit<Plant, 'id' | 'qrCodeValue'>[] }): Promise<{ cultivo: Cultivo; plants: Plant[] }> => {
+export const addCultivo = async (cultivoData: { name: string; startDate: string; notes?: string; plants?: Omit<Plant, 'id' | 'qrCodeValue'>[] }): Promise<{ cultivo: Cultivo; plants?: Plant[] }> => {
   try {
     const user = netlifyIdentity.currentUser();
     if (!user) {
@@ -98,16 +98,19 @@ export const addCultivo = async (cultivoData: { name: string; startDate: string;
     }
 
     // The user ID will be extracted from the JWT token in the Netlify function
+    const bodyData: any = {
+      ...cultivoData,
+      // Ensure startDate is properly formatted
+      startDate: new Date(cultivoData.startDate).toISOString(),
+    };
+    if (!bodyData.plants) delete bodyData.plants;
+
     const result = await fetchWithAuth('addCultivo', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({
-        ...cultivoData,
-        // Ensure startDate is properly formatted
-        startDate: new Date(cultivoData.startDate).toISOString(),
-      }),
+      body: JSON.stringify(bodyData),
     });
     
     return result;


### PR DESCRIPTION
## Summary
- allow addCultivo to create a crop without plants
- update service addCultivo to send optional plants
- simplify new cultivation form to only handle crop data
- improve cultivation list page with summary and empty state

## Testing
- `npx eslint .` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_68408a5e4908832a8de34f059b1ad658