### PR TITLE
Add harvest progress insight

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import PlusIcon from './icons/PlusIcon';
 import ProfileDropdown from './ProfileDropdown';
+import ThemeToggle from './ThemeToggle';
 import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
 import IconButton from '@mui/material/IconButton';
@@ -65,6 +66,7 @@ const Header: React.FC<HeaderProps> = ({
           <IconButton onClick={onOpenAddModal} color="inherit" aria-label={t('header.add_plant')}>
             <PlusIcon className="w-5 h-5" />
           </IconButton>
+          <ThemeToggle />
           <IconButton color="inherit" className="relative">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5">
               <path strokeLinecap="round" strokeLinejoin="round" d="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0" />

--- a/components/PlantCard.tsx
+++ b/components/PlantCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Plant } from '../types';
+import PlantInsight from './PlantInsight';
 
 interface PlantCardProps {
   plant: Plant;
@@ -73,6 +74,7 @@ const PlantCard: React.FC<PlantCardProps> = ({ plant, onClick, selectable, selec
         <div className="p-4">
           <h3 className="text-lg font-semibold text-slate-800 dark:text-slate-100 truncate" title={plant.name}>{plant.name}</h3>
           <p className="text-sm text-slate-600 dark:text-slate-400 truncate" title={plant.strain}>{plant.strain || 'N/A'}</p>
+          <PlantInsight plant={plant} />
         </div>
         {/* Sombra decorativa inferior */}
         <div className="absolute bottom-0 left-0 w-full h-10 bg-gradient-to-t from-green-100/60 to-transparent dark:from-slate-800/60 pointer-events-none" />

--- a/components/PlantInsight.tsx
+++ b/components/PlantInsight.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Plant } from '../types';
+import { useTranslation } from 'react-i18next';
+
+interface PlantInsightProps {
+  plant: Plant;
+}
+
+const PlantInsight: React.FC<PlantInsightProps> = ({ plant }) => {
+  if (!plant.estimatedHarvestDate) return null;
+  const start = new Date(plant.birthDate).getTime();
+  const end = new Date(plant.estimatedHarvestDate).getTime();
+  if (isNaN(start) || isNaN(end) || end <= start) return null;
+  const now = Date.now();
+  const progress = Math.min(Math.max((now - start) / (end - start), 0), 1);
+  const daysLeft = Math.ceil((end - now) / (1000 * 60 * 60 * 24));
+  const { t } = useTranslation();
+  return (
+    <div className="mt-2">
+      <div className="h-2 bg-gray-200 dark:bg-gray-700 rounded overflow-hidden">
+        <div
+          className="bg-emerald-500 h-full transition-all"
+          style={{ width: `${progress * 100}%` }}
+        />
+      </div>
+      <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+        {daysLeft > 0
+          ? t('plant_card.days_to_harvest', { count: daysLeft })
+          : t('plant_card.ready_to_harvest')}
+      </p>
+    </div>
+  );
+};
+
+export default PlantInsight;

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import IconButton from '@mui/material/IconButton';
+import { useTheme } from '../contexts/ThemeContext';
+import { useTranslation } from 'react-i18next';
+import SunIcon from './icons/SunIcon';
+import MoonIcon from './icons/MoonIcon';
+
+const ThemeToggle: React.FC = () => {
+  const { theme, toggleTheme } = useTheme();
+  const { t } = useTranslation();
+
+  const handleToggle = () => {
+    toggleTheme();
+  };
+
+  return (
+    <IconButton onClick={handleToggle} color="inherit" aria-label={t('header.toggle_theme')}>
+      {theme === 'dark' ? <SunIcon className="w-5 h-5" /> : <MoonIcon className="w-5 h-5" />}
+    </IconButton>
+  );
+};
+
+export default ThemeToggle;

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -16,7 +16,8 @@
     "search": "Search plants...",
     "open_menu": "Open menu",
     "scan_qr": "Scan QR",
-    "add_plant": "Add Plant"
+    "add_plant": "Add Plant",
+    "toggle_theme": "Toggle theme"
   },
   "dashboard": {
     "quick_actions": "Quick Actions",
@@ -63,6 +64,11 @@
   "language": {
     "english": "English",
     "portuguese": "Portuguese"
+  },
+  "plant_card": {
+    "days_to_harvest": "{{count}} day to harvest",
+    "days_to_harvest_plural": "{{count}} days to harvest",
+    "ready_to_harvest": "Ready to harvest"
   },
   "loading": "Loading..."
 }

--- a/locales/pt/translation.json
+++ b/locales/pt/translation.json
@@ -16,7 +16,8 @@
     "search": "Buscar plantas...",
     "open_menu": "Abrir menu",
     "scan_qr": "Escanear QR",
-    "add_plant": "Adicionar Planta"
+    "add_plant": "Adicionar Planta",
+    "toggle_theme": "Alternar tema"
   },
   "dashboard": {
     "quick_actions": "Ações Rápidas",
@@ -63,6 +64,11 @@
   "language": {
     "english": "Inglês",
     "portuguese": "Português"
+  },
+  "plant_card": {
+    "days_to_harvest": "Falta {{count}} dia para a colheita",
+    "days_to_harvest_plural": "Faltam {{count}} dias para a colheita",
+    "ready_to_harvest": "Pronto para colher"
   },
   "loading": "Carregando..."
 }


### PR DESCRIPTION
## Summary
- show predicted harvest progress for plants
- translate text for plant insight component

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6842ba8023c0832abaf391c009125495