### PR TITLE
Improve dashboard usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,5 @@ This project uses [Material UI](https://mui.com/) for its base styling along wit
 
 Run the SQL script in `supabase/diary_entries.sql` on your Supabase project to
 create the `diary_entries` table used by the Netlify functions.
+
+Para uma descrição completa da interface em português, consulte [docs/INTERFACE_COMPLETA_PT_BR.md](docs/INTERFACE_COMPLETA_PT_BR.md).

--- a/components/PlantCardSkeleton.tsx
+++ b/components/PlantCardSkeleton.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+const PlantCardSkeleton: React.FC = () => {
+  return (
+    <div className="rounded-3xl shadow-xl bg-gray-800 border border-gray-700 animate-pulse overflow-hidden" style={{minHeight:320}}>
+      <div className="h-48 w-full bg-gray-700" />
+      <div className="p-4 space-y-2">
+        <div className="h-4 bg-gray-700 rounded w-2/3" />
+        <div className="h-3 bg-gray-700 rounded w-1/3" />
+      </div>
+    </div>
+  );
+};
+
+export default PlantCardSkeleton;

--- a/components/PlantaForm.tsx
+++ b/components/PlantaForm.tsx
@@ -2,19 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { PlantStage, PlantHealthStatus, PlantOperationalStatus } from '../types';
 import StrainAutocomplete from './StrainAutocomplete';
 
-const SUBSTRATE_OPTIONS = [
-  { value: '', label: 'Selecione um substrato...' },
-  { value: 'Terra Composta (Solo Orgânico)', label: 'Terra Composta (Solo Orgânico)' },
-  { value: 'Fibra de Coco', label: 'Fibra de Coco' },
-  { value: 'Perlita', label: 'Perlita' },
-  { value: 'Vermiculita', label: 'Vermiculita' },
-  { value: 'Turfa (Peat Moss)', label: 'Turfa (Peat Moss)' },
-  { value: 'Lã de Rocha (Rockwool)', label: 'Lã de Rocha (Rockwool)' },
-  { value: 'Argila Expandida', label: 'Argila Expandida' },
-  { value: 'Solo Inerte', label: 'Solo Inerte' },
-  { value: 'Carolina Soil', label: 'Carolina Soil' },
-  { value: 'Outro', label: 'Outro (Especificar)' }
-];
+import { SUBSTRATE_OPTIONS } from '../constants';
 
 interface PlantaFormProps {
   initialValues?: {

--- a/components/StatsCardSkeleton.tsx
+++ b/components/StatsCardSkeleton.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const StatsCardSkeleton: React.FC = () => {
+  return (
+    <div className="p-4 rounded-xl border border-gray-700 bg-gray-800 shadow-lg animate-pulse">
+      <div className="h-4 bg-gray-700 rounded w-1/3 mb-3" />
+      <div className="h-8 bg-gray-700 rounded w-2/3" />
+    </div>
+  );
+};
+
+export default StatsCardSkeleton;

--- a/constants.ts
+++ b/constants.ts
@@ -38,6 +38,20 @@ export const CULTIVATION_TYPE_OPTIONS = [
   { value: 'Soil', label: 'Solo' },
 ];
 
+export const SUBSTRATE_OPTIONS = [
+  { value: '', label: 'Selecione um substrato...' },
+  { value: 'Terra Composta (Solo Org\u00e2nico)', label: 'Terra Composta (Solo Org\u00e2nico)' },
+  { value: 'Fibra de Coco', label: 'Fibra de Coco' },
+  { value: 'Perlita', label: 'Perlita' },
+  { value: 'Vermiculita', label: 'Vermiculita' },
+  { value: 'Turfa (Peat Moss)', label: 'Turfa (Peat Moss)' },
+  { value: 'L\u00e3 de Rocha (Rockwool)', label: 'L\u00e3 de Rocha (Rockwool)' },
+  { value: 'Argila Expandida', label: 'Argila Expandida' },
+  { value: 'Solo Inerte', label: 'Solo Inerte' },
+  { value: 'Carolina Soil', label: 'Carolina Soil' },
+  { value: 'Outro', label: 'Outro (Especificar)' },
+];
+
 
 export const GENERIC_ERROR_MESSAGE = "Ocorreu um erro. Por favor, tente novamente.";
 export const MOCK_USER_ID = "user_default_01";

--- a/docs/INTERFACE_COMPLETA_PT_BR.md
+++ b/docs/INTERFACE_COMPLETA_PT_BR.md
@@ -1,0 +1,110 @@
+# Descrição Absolutamente Completa da Interface
+
+## 1. Dashboard Inicial
+
+- **Plantios Ativos**
+- **Alertas Críticos**
+- **Últimos Diagnósticos IA**
+- **Próximas Colheitas**
+
+Ações rápidas:
+
+- **Registrar Diário**
+- **Escanear QR**
+- **Criar Novo Plantio**
+
+## 2. Menu Plantas
+
+### Lista de Plantas
+
+- Exibição em lista ou grade
+- Cada card mostra nome/alias, status visual, último registro e botão de registro rápido
+
+### Detalhe da Planta
+
+- Foto atual
+- Linha do tempo de registros
+- Gráficos de histórico (altura, EC, pH)
+- Dados básicos (strain, estágio, dias totais)
+
+Ações disponíveis:
+
+- **Registrar Novo Diário**
+- **Solicitar Análise IA**
+- **Editar Planta**
+
+## 3. Menu Diário
+
+### Tela Inicial
+
+- Calendário com registros diários
+- Opções para adicionar registro e exportar relatório
+
+### Registrar Diário
+
+Campos obrigatórios:
+
+- Altura (cm)
+- EC (condutividade elétrica)
+- pH da solução
+- Irrigação (litros)
+
+Campos opcionais:
+
+- Observações livres
+- Seleção de sintomas comuns
+- Upload de fotos
+- Analisar com IA
+
+Botão principal **Salvar Diário** (destaque em verde neon)
+
+## 4. Menu Scanner QR
+
+- Câmera abre automaticamente
+- Feedback visual ao identificar QR ("Planta encontrada!")
+- Resumo instantâneo dos detalhes da planta
+- Acesso direto para adicionar registro diário
+
+Alternativa manual:
+
+- Campo de busca por ID ou alias
+- Lista de plantas recentes
+
+## 5. Menu Alertas
+
+- Lista de alertas ativos por criticidade
+- Tipos: ambientais, nutricionais e IA
+- Cada alerta traz descrição, data/hora e ações recomendadas
+
+Ações:
+
+- **Marcar como Resolvido**
+- **Ignorar Alerta**
+- **Registrar Diário Corretivo**
+
+## ⚙️ Menu de Configurações
+
+- Perfil do usuário (dados básicos e 2FA)
+- Ambientes e sensores (gestão de estufas e IoT)
+- Usuários e permissões (Admin, Cultivador, Auditor)
+- Plano de assinatura (status e upgrades)
+- Backup e exportação de dados
+
+## 📊 Relatórios e Exportação
+
+- Relatório Diário (PDF ou CSV)
+- Relatório Completo da Planta
+- Relatório Geral do Plantio
+
+## 📸 Diagnóstico IA (OpenAI Vision)
+
+- Upload de imagem com animação de carregamento
+- Diagnóstico resumido em texto e pontos visuais destacados
+- Sugestões práticas (ex.: ajustar EC, verificar pragas)
+
+Ações pós-diagnóstico:
+
+- **Confirmar Diagnóstico**
+- **Solicitar Nova Análise**
+- **Registrar Diário com Diagnóstico**
+

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -34,7 +34,9 @@
     "error_loading_plants": "Error loading plants",
     "add_modal_title": "Add New Plant",
     "adding_plant": "Adding plant...",
-    "no_activity": "Add plants to see activity history"
+    "no_activity": "Add plants to see activity history",
+    "search_placeholder": "Search plants...",
+    "no_results": "No results found"
   },
   "form": {
     "name": "Plant Name",

--- a/locales/pt/translation.json
+++ b/locales/pt/translation.json
@@ -34,7 +34,9 @@
     "error_loading_plants": "Erro ao carregar plantas",
     "add_modal_title": "Adicionar Nova Planta",
     "adding_plant": "Adicionando planta...",
-    "no_activity": "Adicione plantas para ver o histórico de atividades"
+    "no_activity": "Adicione plantas para ver o histórico de atividades",
+    "search_placeholder": "Buscar plantas...",
+    "no_results": "Nenhum resultado encontrado"
   },
   "form": {
     "name": "Nome da Planta",

--- a/pages/DashboardPage.tsx
+++ b/pages/DashboardPage.tsx
@@ -6,7 +6,8 @@ import {
   PLANT_STAGES_OPTIONS, 
   PLANT_HEALTH_STATUS_OPTIONS, 
   PLANT_OPERATIONAL_STATUS_OPTIONS,
-  CULTIVATION_TYPE_OPTIONS
+  CULTIVATION_TYPE_OPTIONS,
+  SUBSTRATE_OPTIONS
 } from '../constants';
 import PlantCard from '../components/PlantCard';
 import LoadingSpinner from '../components/LoadingSpinner';
@@ -22,6 +23,8 @@ import QrCodeScanner from '../components/QrCodeScanner';
 import Sidebar from '../components/Sidebar';
 import Header from '../components/Header';
 import StatsCard from '../components/StatsCard';
+import StatsCardSkeleton from '../components/StatsCardSkeleton';
+import PlantCardSkeleton from '../components/PlantCardSkeleton';
 import QuickActions from '../components/QuickActions';
 import LeafIcon from '../components/icons/LeafIcon';
 
@@ -40,6 +43,7 @@ const DashboardPage: React.FC = () => {
   });
   const [lastTempUpdate, setLastTempUpdate] = useState<number>(0);
   const [tempAlert, setTempAlert] = useState<string | null>(null);
+  const [searchTerm, setSearchTerm] = useState('');
 
   const initialFormState: NewPlantData = {
     name: '',
@@ -174,6 +178,11 @@ const DashboardPage: React.FC = () => {
     };
   }, [plants, user, isLoggedIn]);
 
+  const filteredPlants = plants.filter(p =>
+    p.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+    (p.strain && p.strain.toLowerCase().includes(searchTerm.toLowerCase()))
+  );
+
   const inputStyle = "mt-1 block w-full px-3 py-2.5 bg-[#EAEAEA] dark:bg-slate-700 border border-gray-300 dark:border-slate-600 text-[#3E3E3E] dark:text-slate-100 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[#7AC943] focus:border-[#7AC943] sm:text-sm transition-colors placeholder:text-gray-400 dark:placeholder:text-gray-400";
   const selectStyle = "mt-1 block w-full px-3 py-2.5 bg-[#EAEAEA] dark:bg-slate-700 border border-gray-300 dark:border-slate-600 text-[#3E3E3E] dark:text-slate-100 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[#7AC943] focus:border-[#7AC943] sm:text-sm transition-colors";
 
@@ -200,37 +209,47 @@ const DashboardPage: React.FC = () => {
             </div>
           )}
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            <StatsCard
-              title={t('dashboard.total_plants')}
-              value={stats.totalPlants}
-              change="+2" // placeholder
-              trend="up"
-              icon={<LeafIcon className="w-5 h-5" />}
-              color="green"
-            />
-            <StatsCard
-              title={t('dashboard.active_zones')}
-              value={stats.activeZones}
-              color="blue"
-              icon={
-                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5">
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" />
-                </svg>
-              }
-            />
-            <StatsCard
-              title={t('dashboard.avg_temperature')}
-              value={`${Math.round(stats.avgTemperature)}°C`}
-              change=""
-              trend="neutral"
-              color="yellow"
-              icon={
-                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5">
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M15.362 5.214A8.252 8.252 0 0 1 12 21 8.25 8.25 0 0 1 6.038 7.047 8.287 8.287 0 0 0 9 9.601a8.983 8.983 0 0 1 3.361-6.867 8.21 8.21 0 0 0 3 2.48Z" />
-                </svg>
-              }
-            />
-
+            {isLoading ? (
+              <>
+                <StatsCardSkeleton />
+                <StatsCardSkeleton />
+                <StatsCardSkeleton />
+                <StatsCardSkeleton />
+              </>
+            ) : (
+              <>
+                <StatsCard
+                  title={t('dashboard.total_plants')}
+                  value={stats.totalPlants}
+                  change="+2" // placeholder
+                  trend="up"
+                  icon={<LeafIcon className="w-5 h-5" />}
+                  color="green"
+                />
+                <StatsCard
+                  title={t('dashboard.active_zones')}
+                  value={stats.activeZones}
+                  color="blue"
+                  icon={
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5">
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" />
+                    </svg>
+                  }
+                />
+                <StatsCard
+                  title={t('dashboard.avg_temperature')}
+                  value={`${Math.round(stats.avgTemperature)}°C`}
+                  change=""
+                  trend="neutral"
+                  color="yellow"
+                  icon={
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5">
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M15.362 5.214A8.252 8.252 0 0 1 12 21 8.25 8.25 0 0 1 6.038 7.047 8.287 8.287 0 0 0 9 9.601a8.983 8.983 0 0 1 3.361-6.867 8.21 8.21 0 0 0 3 2.48Z" />
+                    </svg>
+                  }
+                />
+              </>
+            )}
           </div>
 
           {/* Quick Actions */}
@@ -252,10 +271,20 @@ const DashboardPage: React.FC = () => {
                 {t('dashboard.view_all')}
               </Link>
             </div>
-            
+            <div className="mb-4">
+              <input
+                type="text"
+                placeholder={t('dashboard.search_placeholder')}
+                value={searchTerm}
+                onChange={e => setSearchTerm(e.target.value)}
+                className={inputStyle}
+              />
+            </div>
             {isLoading ? (
-              <div className="flex justify-center items-center h-64">
-                <LoadingSpinner size="lg" />
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                {Array.from({ length: 3 }).map((_, idx) => (
+                  <PlantCardSkeleton key={idx} />
+                ))}
               </div>
             ) : error ? (
               <div className="bg-red-900/30 text-red-300 p-4 rounded-lg">
@@ -265,13 +294,17 @@ const DashboardPage: React.FC = () => {
               <div className="bg-blue-900/30 text-blue-300 p-4 rounded-lg">
                 <p>{t('dashboard.no_plants')}</p>
               </div>
+            ) : filteredPlants.length === 0 ? (
+              <div className="bg-blue-900/30 text-blue-300 p-4 rounded-lg">
+                <p>{t('dashboard.no_results')}</p>
+              </div>
             ) : (
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                {plants.slice(0, 6).map(plant => (
-                  <PlantCard 
-                    key={plant.id} 
-                    plant={plant} 
-                    onClick={() => navigate(`/plant/${plant.id}`)} 
+                {filteredPlants.slice(0, 6).map(plant => (
+                  <PlantCard
+                    key={plant.id}
+                    plant={plant}
+                    onClick={() => navigate(`/plant/${plant.id}`)}
                   />
                 ))}
               </div>
@@ -384,7 +417,17 @@ const DashboardPage: React.FC = () => {
               </div>
               <div>
                 <label htmlFor="substrate" className="block text-sm font-medium text-[#3E3E3E] dark:text-slate-200 mb-0.5">{t('form.substrate')}</label>
-                <input type="text" name="substrate" id="substrate" value={newPlantForm.substrate || ''} onChange={handleInputChange} className={inputStyle} placeholder="Ex: Coco, Perlita, Mix próprio"/>
+                <select
+                  name="substrate"
+                  id="substrate"
+                  value={newPlantForm.substrate}
+                  onChange={handleInputChange}
+                  className={selectStyle}
+                >
+                  {SUBSTRATE_OPTIONS.map(option => (
+                    <option key={option.value} value={option.value}>{option.label}</option>
+                  ))}
+                </select>
               </div>
               <div>
                 <label htmlFor="estimatedHarvestDate" className="block text-sm font-medium text-[#3E3E3E] dark:text-slate-200 mb-0.5">{t('form.estimated_harvest')}</label>


### PR DESCRIPTION
## Summary
- add skeleton components for stats and plant cards
- implement plant search filtering with translations
- show skeletons and search input on dashboard

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6842c4785ea0832aa6dd22f30e2d80fc