### PR TITLE
Fix stage enum and modal prop usage

### DIFF
--- a/pages/CultivoDetailPage.tsx
+++ b/pages/CultivoDetailPage.tsx
@@ -124,9 +124,9 @@ const CultivoDetailPage: React.FC = () => {
           activePlants.map(async (p) => {
             console.log(`[handleFinishCultivo] Atualizando planta ${p.id} para colhida`);
             try {
-              await updatePlant(p.id, { 
-                operationalStatus: PlantOperationalStatus.HARVESTED, 
-                currentStage: 'Secagem' 
+              await updatePlant(p.id, {
+                operationalStatus: PlantOperationalStatus.HARVESTED,
+                currentStage: PlantStage.DRYING
               });
               console.log(`[handleFinishCultivo] Planta ${p.id} atualizada com sucesso`);
             } catch (plantError) {
@@ -302,7 +302,7 @@ const CultivoDetailPage: React.FC = () => {
       </Button>
 
       {/* Modal de confirmação */}
-      <Modal isOpen={showFinishModal} onClose={() => setShowFinishModal(false)} title="Finalizar Cultivo" size="md">
+      <Modal isOpen={showFinishModal} onClose={() => setShowFinishModal(false)} title="Finalizar Cultivo" maxWidth="md">
         <div className="flex flex-col items-center gap-4 p-2">
           <CheckCircleIcon className="w-16 h-16 text-green-500 mb-2" />
           <span className="text-lg font-bold text-green-800 dark:text-green-300 text-center">Tem certeza que deseja finalizar este cultivo?</span>

--- a/pages/DashboardPage.tsx
+++ b/pages/DashboardPage.tsx
@@ -361,7 +361,7 @@ const DashboardPage: React.FC = () => {
         </main>
       </div>
       
-      <Modal isOpen={isAddModalOpen} onClose={() => setIsAddModalOpen(false)} title={t('dashboard.add_modal_title')} size="xl">
+      <Modal isOpen={isAddModalOpen} onClose={() => setIsAddModalOpen(false)} title={t('dashboard.add_modal_title')} maxWidth="xl">
         <form onSubmit={handleAddPlant} className="space-y-4">
           {isAddingPlant ? (
             <div className="flex justify-center items-center py-2">
@@ -468,12 +468,12 @@ const DashboardPage: React.FC = () => {
       </Modal>
 
       {/* QR Code Scanner Modal */}
-      <Modal
-        isOpen={isScannerModalOpen}
-        onClose={() => setIsScannerModalOpen(false)}
-        title={t('header.scan_qr')}
-        size="sm"
-      >
+        <Modal
+          isOpen={isScannerModalOpen}
+          onClose={() => setIsScannerModalOpen(false)}
+          title={t('header.scan_qr')}
+          maxWidth="sm"
+        >
         {scannerError && (
           <div className="mb-4 p-3 bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300 rounded-lg">
             {scannerError}


### PR DESCRIPTION
## Summary
- set PlantStage enum when finalizing cultivo
- use maxWidth prop in Modal components

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module '@mui/material/Dialog')*

------
https://chatgpt.com/codex/tasks/task_e_6842c9dd1d84832aa384c8fe552aaa0e