### PR TITLE
Add dark mode switch and settings page

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -12,6 +12,7 @@ import NovaPlantaPage from './pages/NovaPlantaPage';
 import CultivoEtiquetasPage from './pages/CultivoEtiquetasPage';
 import CultivoDetailPage from './pages/CultivoDetailPage';
 import GrowsPage from './pages/GrowsPage';
+import SettingsPage from './pages/SettingsPage';
 import { PlantProvider } from './contexts/PlantContext';
 import ProtectedRoute from './components/ProtectedRoute';
 
@@ -105,6 +106,14 @@ const App: React.FC = () => {
             element={
               <ProtectedRoute>
                 <AllPlantsPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/settings"
+            element={
+              <ProtectedRoute>
+                <SettingsPage />
               </ProtectedRoute>
             }
           />

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,9 +1,51 @@
 import React from 'react';
-import IconButton from '@mui/material/IconButton';
+import { styled } from '@mui/material/styles';
+import Switch from '@mui/material/Switch';
 import { useTheme } from '../contexts/ThemeContext';
 import { useTranslation } from 'react-i18next';
-import SunIcon from './icons/SunIcon';
-import MoonIcon from './icons/MoonIcon';
+
+const MaterialUISwitch = styled(Switch)(({ theme }) => ({
+  width: 62,
+  height: 34,
+  padding: 7,
+  '& .MuiSwitch-switchBase': {
+    margin: 1,
+    padding: 0,
+    transform: 'translateX(6px)',
+    '&.Mui-checked': {
+      color: '#fff',
+      transform: 'translateX(22px)',
+      '& .MuiSwitch-thumb:before': {
+        backgroundImage: `url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" height="20" width="20" viewBox="0 0 20 20"><path fill="${encodeURIComponent('#fff')}" d="M4.2 2.5l-.7 1.8-1.8.7 1.8.7.7 1.8.6-1.8L6.7 5l-1.9-.7-.6-1.8zm15 8.3a6.7 6.7 0 11-6.6-6.6 5.8 5.8 0 006.6 6.6z"/></svg>')`,
+      },
+      '& + .MuiSwitch-track': {
+        opacity: 1,
+        backgroundColor: theme.palette.mode === 'dark' ? '#8796A5' : '#aab4be',
+      },
+    },
+  },
+  '& .MuiSwitch-thumb': {
+    backgroundColor: theme.palette.mode === 'dark' ? '#003892' : '#001e3c',
+    width: 32,
+    height: 32,
+    '&::before': {
+      content: "''",
+      position: 'absolute',
+      width: '100%',
+      height: '100%',
+      left: 0,
+      top: 0,
+      backgroundRepeat: 'no-repeat',
+      backgroundPosition: 'center',
+      backgroundImage: `url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" height="20" width="20" viewBox="0 0 20 20"><path fill="${encodeURIComponent('#fff')}" d="M9.305 1.667V3.75h1.389V1.667h-1.39zm-4.707 1.95l-.982.982L5.09 6.072l.982-.982-1.473-1.473zm10.802 0L13.927 5.09l.982.982 1.473-1.473-.982-.982zM10 5.139a4.872 4.872 0 00-4.862 4.86A4.872 4.872 0 0010 14.862 4.872 4.872 0 0014.86 10 4.872 4.872 0 0010 5.139zm0 1.389A3.462 3.462 0 0113.471 10a3.462 3.462 0 01-3.473 3.472A3.462 3.462 0 016.527 10 3.462 3.462 0 0110 6.528zM1.665 9.305v1.39h2.083v-1.39H1.666zm14.583 0v1.39h2.084v-1.39h-2.084zM5.09 13.928L3.616 15.4l.982.982 1.473-1.473-.982-.982zm9.82 0l-.982.982 1.473 1.473.982-.982-1.473-1.473zM9.305 16.25v2.083h1.389V16.25h-1.39z"/></svg>')`,
+    },
+  },
+  '& .MuiSwitch-track': {
+    opacity: 1,
+    backgroundColor: theme.palette.mode === 'dark' ? '#8796A5' : '#aab4be',
+    borderRadius: 20 / 2,
+  },
+}));
 
 const ThemeToggle: React.FC = () => {
   const { theme, toggleTheme } = useTheme();
@@ -14,9 +56,11 @@ const ThemeToggle: React.FC = () => {
   };
 
   return (
-    <IconButton onClick={handleToggle} color="inherit" aria-label={t('header.toggle_theme')}>
-      {theme === 'dark' ? <SunIcon className="w-5 h-5" /> : <MoonIcon className="w-5 h-5" />}
-    </IconButton>
+    <MaterialUISwitch
+      checked={theme === 'dark'}
+      onChange={handleToggle}
+      inputProps={{ 'aria-label': t('header.toggle_theme') }}
+    />
   );
 };
 

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -73,4 +73,8 @@
     "ready_to_harvest": "Ready to harvest"
   },
   "loading": "Loading..."
+  ,"settingsPage": {
+    "title": "Settings",
+    "theme": "Dark mode"
+  }
 }

--- a/locales/pt/translation.json
+++ b/locales/pt/translation.json
@@ -73,4 +73,8 @@
     "ready_to_harvest": "Pronto para colher"
   },
   "loading": "Carregando..."
+  ,"settingsPage": {
+    "title": "Configurações",
+    "theme": "Modo escuro"
+  }
 }

--- a/pages/SettingsPage.tsx
+++ b/pages/SettingsPage.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import Sidebar from '../components/Sidebar';
+import Header from '../components/Header';
+import ThemeToggle from '../components/ThemeToggle';
+import { useTranslation } from 'react-i18next';
+
+const SettingsPage: React.FC = () => {
+  const [isSidebarOpen, setIsSidebarOpen] = React.useState(false);
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex h-screen bg-gray-900 text-white overflow-hidden">
+      <Sidebar isOpen={isSidebarOpen} onClose={() => setIsSidebarOpen(false)} />
+      <div className="flex-1 flex flex-col overflow-hidden">
+        <Header
+          title={t('settingsPage.title')}
+          onOpenSidebar={() => setIsSidebarOpen(true)}
+          onOpenAddModal={() => {}}
+          onOpenScannerModal={() => {}}
+        />
+        <main className="flex-1 overflow-y-auto p-4 md:p-6 space-y-6">
+          <div className="bg-gray-800 p-4 rounded-lg flex items-center justify-between">
+            <span>{t('settingsPage.theme')}</span>
+            <ThemeToggle />
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+};
+
+export default SettingsPage;
+


### PR DESCRIPTION
## Summary
- add customizable switch for theme toggle
- create a basic settings page where the theme can be changed
- add route for settings page
- provide translations for the new page

## Testing
- `npm ci`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68473b50cdcc832a9fcd173e441675fa