### PR TITLE
Add theme switch and improve plant cards

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -12,6 +12,7 @@ import NovaPlantaPage from './pages/NovaPlantaPage';
 import CultivoEtiquetasPage from './pages/CultivoEtiquetasPage';
 import CultivoDetailPage from './pages/CultivoDetailPage';
 import GrowsPage from './pages/GrowsPage';
+import SettingsPage from './pages/SettingsPage';
 import { PlantProvider } from './contexts/PlantContext';
 import ProtectedRoute from './components/ProtectedRoute';
 
@@ -105,6 +106,14 @@ const App: React.FC = () => {
             element={
               <ProtectedRoute>
                 <AllPlantsPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/settings"
+            element={
+              <ProtectedRoute>
+                <SettingsPage />
               </ProtectedRoute>
             }
           />

--- a/components/HamburgerMenu.tsx
+++ b/components/HamburgerMenu.tsx
@@ -4,6 +4,7 @@ import XMarkIcon from './icons/XMarkIcon';
 import { useAuth } from '../contexts/AuthContext';
 import { APP_NAME } from '../constants';
 import LeafIcon from './icons/LeafIcon'; // Para o logo
+import { useTranslation } from 'react-i18next';
 
 interface HamburgerMenuProps {
   isOpen: boolean;
@@ -12,6 +13,7 @@ interface HamburgerMenuProps {
 
 const HamburgerMenu: React.FC<HamburgerMenuProps> = ({ isOpen, onClose }) => {
   const auth = useAuth();
+  const { t } = useTranslation();
   const [lastPlantId, setLastPlantId] = React.useState<string | null>(null);
   const [lastPlantName, setLastPlantName] = React.useState<string | null>(null);
 

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -66,13 +66,13 @@ const Header: React.FC<HeaderProps> = ({
           <IconButton onClick={onOpenAddModal} color="inherit" aria-label={t('header.add_plant')}>
             <PlusIcon className="w-5 h-5" />
           </IconButton>
-          <ThemeToggle />
           <IconButton color="inherit" className="relative">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5">
               <path strokeLinecap="round" strokeLinejoin="round" d="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0" />
             </svg>
             <span className="absolute top-0 right-0 block h-2 w-2 rounded-full bg-red-500 ring-2 ring-gray-900"></span>
           </IconButton>
+          <ThemeToggle className="mx-2" />
           <div className="relative">
             <IconButton onClick={() => setIsProfileDropdownOpen(prev => !prev)} size="small" aria-controls="user-menu" aria-haspopup="true">
               <Avatar sx={{ bgcolor: 'success.main', width: 32, height: 32, fontSize: 14 }}>{initials}</Avatar>

--- a/components/PlantCard.tsx
+++ b/components/PlantCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Plant } from '../types';
+import { Plant, PlantHealthStatus } from '../types';
+import { useTranslation } from 'react-i18next';
 import PlantInsight from './PlantInsight';
 import TiltedCard from './TiltedCard';
 
@@ -38,6 +39,8 @@ const PlantCard: React.FC<PlantCardProps> = ({ plant, onClick, selectable, selec
   //   }
   // };
 
+  const { t } = useTranslation();
+
   const handleClick = () => {
     if (selectable) {
       onSelectToggle && onSelectToggle();
@@ -47,6 +50,12 @@ const PlantCard: React.FC<PlantCardProps> = ({ plant, onClick, selectable, selec
       window.location.href = `/plant/${plant.id}`;
     }
   };
+
+  const ageDays = React.useMemo(() => {
+    const birth = new Date(plant.birthDate).getTime();
+    if (!birth) return null;
+    return Math.floor((Date.now() - birth) / (1000 * 60 * 60 * 24));
+  }, [plant.birthDate]);
 
   return (
     <TiltedCard
@@ -78,8 +87,18 @@ const PlantCard: React.FC<PlantCardProps> = ({ plant, onClick, selectable, selec
 
           {/* Conteúdo de texto do card */}
           <div className="absolute bottom-0 left-0 right-0 p-4 bg-white/80 dark:bg-slate-800/80 backdrop-blur rounded-b-3xl">
-            <h3 className="text-lg font-semibold text-slate-800 dark:text-slate-100 truncate" title={plant.name}>{plant.name}</h3>
+            <h3 className="text-xl font-bold text-slate-800 dark:text-slate-100 truncate" title={plant.name}>{plant.name}</h3>
             <p className="text-sm text-slate-600 dark:text-slate-400 truncate" title={plant.strain}>{plant.strain || 'N/A'}</p>
+            {ageDays !== null && (
+              <p className="text-xs text-slate-500 dark:text-slate-400">
+                {t(ageDays === 1 ? 'plant_card.age' : 'plant_card.age_plural', { count: ageDays })}
+              </p>
+            )}
+            {plant.healthStatus && plant.healthStatus !== PlantHealthStatus.HEALTHY && (
+              <p className="text-xs text-red-500">
+                {t('plant_card.problem', { status: plant.healthStatus })}
+              </p>
+            )}
             <PlantInsight plant={plant} />
           </div>
 

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,11 +1,57 @@
 import React from 'react';
-import IconButton from '@mui/material/IconButton';
+import { styled } from '@mui/material/styles';
+import Switch from '@mui/material/Switch';
 import { useTheme } from '../contexts/ThemeContext';
 import { useTranslation } from 'react-i18next';
-import SunIcon from './icons/SunIcon';
-import MoonIcon from './icons/MoonIcon';
 
-const ThemeToggle: React.FC = () => {
+const MaterialUISwitch = styled(Switch)(({ theme }) => ({
+  width: 62,
+  height: 34,
+  padding: 7,
+  '& .MuiSwitch-switchBase': {
+    margin: 1,
+    padding: 0,
+    transform: 'translateX(6px)',
+    '&.Mui-checked': {
+      color: '#fff',
+      transform: 'translateX(22px)',
+      '& .MuiSwitch-thumb:before': {
+        backgroundImage: `url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" height="20" width="20" viewBox="0 0 20 20"><path fill="${encodeURIComponent('#fff')}" d="M4.2 2.5l-.7 1.8-1.8.7 1.8.7.7 1.8.6-1.8L6.7 5l-1.9-.7-.6-1.8zm15 8.3a6.7 6.7 0 11-6.6-6.6 5.8 5.8 0 006.6 6.6z"/></svg>')`,
+      },
+      '& + .MuiSwitch-track': {
+        opacity: 1,
+        backgroundColor: theme.palette.mode === 'dark' ? '#8796A5' : '#aab4be',
+      },
+    },
+  },
+  '& .MuiSwitch-thumb': {
+    backgroundColor: theme.palette.mode === 'dark' ? '#003892' : '#001e3c',
+    width: 32,
+    height: 32,
+    '&::before': {
+      content: "''",
+      position: 'absolute',
+      width: '100%',
+      height: '100%',
+      left: 0,
+      top: 0,
+      backgroundRepeat: 'no-repeat',
+      backgroundPosition: 'center',
+      backgroundImage: `url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" height="20" width="20" viewBox="0 0 20 20"><path fill="${encodeURIComponent('#fff')}" d="M9.305 1.667V3.75h1.389V1.667h-1.39zm-4.707 1.95l-.982.982L5.09 6.072l.982-.982-1.473-1.473zm10.802 0L13.927 5.09l.982.982 1.473-1.473-.982-.982zM10 5.139a4.872 4.872 0 00-4.862 4.86A4.872 4.872 0 0010 14.862 4.872 4.872 0 0014.86 10 4.872 4.872 0 0010 5.139zm0 1.389A3.462 3.462 0 0113.471 10a3.462 3.462 0 01-3.473 3.472A3.462 3.462 0 016.527 10 3.462 3.462 0 0110 6.528zM1.665 9.305v1.39h2.083v-1.39H1.666zm14.583 0v1.39h2.084v-1.39h-2.084zM5.09 13.928L3.616 15.4l.982.982 1.473-1.473-.982-.982zm9.82 0l-.982.982 1.473 1.473.982-.982-1.473-1.473zM9.305 16.25v2.083h1.389V16.25h-1.39z"/></svg>')`,
+    },
+  },
+  '& .MuiSwitch-track': {
+    opacity: 1,
+    backgroundColor: theme.palette.mode === 'dark' ? '#8796A5' : '#aab4be',
+    borderRadius: 20 / 2,
+  },
+}));
+
+interface ThemeToggleProps {
+  className?: string;
+}
+
+const ThemeToggle: React.FC<ThemeToggleProps> = ({ className }) => {
   const { theme, toggleTheme } = useTheme();
   const { t } = useTranslation();
 
@@ -14,9 +60,12 @@ const ThemeToggle: React.FC = () => {
   };
 
   return (
-    <IconButton onClick={handleToggle} color="inherit" aria-label={t('header.toggle_theme')}>
-      {theme === 'dark' ? <SunIcon className="w-5 h-5" /> : <MoonIcon className="w-5 h-5" />}
-    </IconButton>
+    <MaterialUISwitch
+      className={className}
+      checked={theme === 'dark'}
+      onChange={handleToggle}
+      inputProps={{ 'aria-label': t('header.toggle_theme') }}
+    />
   );
 };
 

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -70,7 +70,15 @@
   "plant_card": {
     "days_to_harvest": "{{count}} day to harvest",
     "days_to_harvest_plural": "{{count}} days to harvest",
-    "ready_to_harvest": "Ready to harvest"
+    "ready_to_harvest": "Ready to harvest",
+    "age": "{{count}} day old",
+    "age_plural": "{{count}} days old",
+    "problem": "Problem: {{status}}"
   },
-  "loading": "Loading..."
+  "loading": "Loading...",
+  "settingsPage": {
+    "title": "Settings",
+    "theme": "Dark mode"
+  }
 }
+

--- a/locales/pt/translation.json
+++ b/locales/pt/translation.json
@@ -70,7 +70,15 @@
   "plant_card": {
     "days_to_harvest": "Falta {{count}} dia para a colheita",
     "days_to_harvest_plural": "Faltam {{count}} dias para a colheita",
-    "ready_to_harvest": "Pronto para colher"
+    "ready_to_harvest": "Pronto para colher",
+    "age": "{{count}} dia de vida",
+    "age_plural": "{{count}} dias de vida",
+    "problem": "Problema: {{status}}"
   },
-  "loading": "Carregando..."
+  "loading": "Carregando...",
+  "settingsPage": {
+    "title": "Configurações",
+    "theme": "Modo escuro"
+  }
 }
+

--- a/pages/SettingsPage.tsx
+++ b/pages/SettingsPage.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import Sidebar from '../components/Sidebar';
+import Header from '../components/Header';
+import ThemeToggle from '../components/ThemeToggle';
+import { useTranslation } from 'react-i18next';
+
+const SettingsPage: React.FC = () => {
+  const [isSidebarOpen, setIsSidebarOpen] = React.useState(false);
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex h-screen bg-gray-900 text-white overflow-hidden">
+      <Sidebar isOpen={isSidebarOpen} onClose={() => setIsSidebarOpen(false)} />
+      <div className="flex-1 flex flex-col overflow-hidden">
+        <Header
+          title={t('settingsPage.title')}
+          onOpenSidebar={() => setIsSidebarOpen(true)}
+          onOpenAddModal={() => {}}
+          onOpenScannerModal={() => {}}
+        />
+        <main className="flex-1 overflow-y-auto p-4 md:p-6 space-y-6">
+          <div className="bg-gray-800 p-4 rounded-lg flex items-center justify-between">
+            <span>{t('settingsPage.theme')}</span>
+            <ThemeToggle />
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+};
+
+export default SettingsPage;
+


### PR DESCRIPTION
## Summary
- keep theme toggle near user avatar in header
- add settings page for dark mode switch
- show plant age and health on plant cards
- fix locale JSON trailing newline for Netlify

## Testing
- `npm ci --prefer-offline --no-audit` *(fails: sharp download via proxy)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68473b50cdcc832a9fcd173e441675fa