### PR TITLE
Enable dark mode and card click handling

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -4,7 +4,6 @@ import { useAuth } from '../contexts/AuthContext';
 import { MdMenu, MdSearch, MdQrCodeScanner, MdNotifications, MdAdd } from 'react-icons/md';
 import PlusIcon from './icons/PlusIcon';
 import ProfileDropdown from './ProfileDropdown';
-import ThemeToggle from './ThemeToggle';
 import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
 import IconButton from '@mui/material/IconButton';
@@ -65,7 +64,6 @@ const Header: React.FC<HeaderProps> = ({
             <MdNotifications size={20} />
             <span className="absolute top-0 right-0 block h-2 w-2 rounded-full bg-red-500 ring-2 ring-gray-900"></span>
           </IconButton>
-          <ThemeToggle className="mx-2" />
           <div className="relative">
             <IconButton onClick={() => setIsProfileDropdownOpen(prev => !prev)} size="small" aria-controls="user-menu" aria-haspopup="true">
               <Avatar sx={{ bgcolor: 'success.main', width: 32, height: 32, fontSize: 14 }}>{initials}</Avatar>

--- a/components/TiltedCard.css
+++ b/components/TiltedCard.css
@@ -43,9 +43,11 @@
 
 .tilted-card-overlay {
   position: absolute;
-  top: 0;
-  left: 0;
+  inset: 0;
   z-index: 2;
+  width: 100%;
+  height: 100%;
+  pointer-events: auto;
   will-change: transform;
   transform: translateZ(30px);
 }

--- a/contexts/ThemeContext.tsx
+++ b/contexts/ThemeContext.tsx
@@ -18,6 +18,16 @@ export const ThemeProvider: React.FC<{ children: ReactNode }> = ({ children }) =
     return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
   });
 
+  // Sync with system preference when user hasn't chosen a theme yet
+  useEffect(() => {
+    const storedTheme = localStorage.getItem('theme') as Theme | null;
+    if (storedTheme) return;
+    const media = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = () => setTheme(media.matches ? 'dark' : 'light');
+    media.addEventListener('change', handler);
+    return () => media.removeEventListener('change', handler);
+  }, []);
+
   useEffect(() => {
     const root = window.document.documentElement;
     if (theme === 'dark') {


### PR DESCRIPTION
## Summary
- sync theme with system preference when not set
- remove header toggle so dark mode only lives in Settings
- make TiltedCard overlays full-size so clicks work

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68475eecbbe8832ab9fa4eca7a297ae9