### PR TITLE
Redesigned dashboard widgets

### DIFF
--- a/components/QuickActions.tsx
+++ b/components/QuickActions.tsx
@@ -11,20 +11,20 @@ interface QuickActionProps {
 
 const QuickAction: React.FC<QuickActionProps> = ({ title, icon, color, onClick }) => {
   const colorMap = {
-    green: 'bg-emerald-600 hover:bg-emerald-700',
-    blue: 'bg-blue-600 hover:bg-blue-700',
-    yellow: 'bg-yellow-600 hover:bg-yellow-700',
-    red: 'bg-red-600 hover:bg-red-700',
-    purple: 'bg-purple-600 hover:bg-purple-700'
+    green: 'from-emerald-500 to-green-600',
+    blue: 'from-blue-500 to-blue-700',
+    yellow: 'from-yellow-400 to-amber-500',
+    red: 'from-red-500 to-rose-600',
+    purple: 'from-purple-500 to-violet-600'
   };
 
   return (
     <button
       onClick={onClick}
-      className={`${colorMap[color]} text-white p-4 rounded-xl shadow-lg flex flex-col items-center justify-center gap-2 transition-transform hover:scale-105 w-full h-full`}
+      className={`bg-gradient-to-br ${colorMap[color]} text-white w-16 h-16 md:w-20 md:h-20 rounded-full flex flex-col items-center justify-center shadow-md hover:shadow-xl transition-transform hover:scale-110`}
     >
-      <div className="text-3xl">{icon}</div>
-      <span className="text-sm font-medium">{title}</span>
+      <div className="text-xl md:text-2xl mb-1">{icon}</div>
+      <span className="text-[10px] md:text-xs font-medium leading-none">{title}</span>
     </button>
   );
 };
@@ -44,7 +44,7 @@ const QuickActions: React.FC<QuickActionsProps> = ({
 }) => {
   const { t } = useTranslation();
   return (
-    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
       <QuickAction
         title={t('header.add_plant')}
         icon={<MdAdd size={32} />}

--- a/components/StatsCard.tsx
+++ b/components/StatsCard.tsx
@@ -11,11 +11,11 @@ interface StatsCardProps {
 
 const StatsCard: React.FC<StatsCardProps> = ({ title, value, change, trend, icon, color }) => {
   const colorMap = {
-    green: 'bg-emerald-900/30 text-emerald-400 border-emerald-500/50',
-    blue: 'bg-blue-900/30 text-blue-400 border-blue-500/50',
-    yellow: 'bg-yellow-900/30 text-yellow-400 border-yellow-500/50',
-    red: 'bg-red-900/30 text-red-400 border-red-500/50',
-    purple: 'bg-purple-900/30 text-purple-400 border-purple-500/50'
+    green: 'bg-gradient-to-br from-emerald-500 to-green-700 text-white',
+    blue: 'bg-gradient-to-br from-blue-500 to-blue-700 text-white',
+    yellow: 'bg-gradient-to-br from-yellow-400 to-amber-500 text-white',
+    red: 'bg-gradient-to-br from-red-500 to-rose-600 text-white',
+    purple: 'bg-gradient-to-br from-purple-500 to-violet-700 text-white'
   };
 
   const trendMap = {
@@ -25,19 +25,40 @@ const StatsCard: React.FC<StatsCardProps> = ({ title, value, change, trend, icon
   };
 
   const iconBgColorMap = {
-    green: 'bg-emerald-500/20 text-emerald-500',
-    blue: 'bg-blue-500/20 text-blue-500',
-    yellow: 'bg-yellow-500/20 text-yellow-500',
-    red: 'bg-red-500/20 text-red-500',
-    purple: 'bg-purple-500/20 text-purple-500'
+    green: 'bg-emerald-600/90 text-white',
+    blue: 'bg-blue-600/90 text-white',
+    yellow: 'bg-yellow-500/90 text-white',
+    red: 'bg-red-600/90 text-white',
+    purple: 'bg-purple-600/90 text-white'
   };
 
+  const [displayValue, setDisplayValue] = React.useState(
+    typeof value === 'number' ? 0 : value
+  );
+
+  React.useEffect(() => {
+    if (typeof value === 'number') {
+      const start = performance.now();
+      const duration = 600;
+      const animate = (now: number) => {
+        const progress = Math.min((now - start) / duration, 1);
+        setDisplayValue(Math.round(progress * value));
+        if (progress < 1) requestAnimationFrame(animate);
+      };
+      requestAnimationFrame(animate);
+    } else {
+      setDisplayValue(value);
+    }
+  }, [value]);
+
   return (
-    <div className={`p-4 rounded-xl border ${colorMap[color]} bg-gray-800 shadow-lg transition-all hover:translate-y-[-2px]`}>
+    <div
+      className={`p-5 rounded-3xl ${colorMap[color]} shadow-md hover:shadow-xl transition-all hover:-translate-y-1`}
+    >
       <div className="flex items-start justify-between">
         <div>
-          <h3 className="text-gray-400 text-sm font-medium mb-1">{title}</h3>
-          <p className="text-2xl font-bold text-white">{value}</p>
+          <h3 className="text-gray-100 text-sm font-medium mb-1">{title}</h3>
+          <p className="text-3xl font-semibold text-white leading-tight">{displayValue}</p>
           {change && (
             <div className={`text-xs mt-1 ${trend ? trendMap[trend] : ''}`}>
               {trend === 'up' && '▲ '}
@@ -46,7 +67,7 @@ const StatsCard: React.FC<StatsCardProps> = ({ title, value, change, trend, icon
             </div>
           )}
         </div>
-        <div className={`p-2 rounded-lg ${iconBgColorMap[color]}`}>
+        <div className={`p-2 rounded-full ${iconBgColorMap[color]}`}>
           {icon}
         </div>
       </div>

--- a/pages/DashboardPage.tsx
+++ b/pages/DashboardPage.tsx
@@ -187,7 +187,7 @@ const DashboardPage: React.FC = () => {
   const selectStyle = "mt-1 block w-full px-3 py-2.5 bg-[#EAEAEA] dark:bg-slate-700 border border-gray-300 dark:border-slate-600 text-[#3E3E3E] dark:text-slate-100 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[#7AC943] focus:border-[#7AC943] sm:text-sm transition-colors";
 
   return (
-    <div className="flex h-screen bg-gray-900 text-white overflow-hidden">
+    <div className="flex h-screen bg-gray-50 text-gray-900 dark:bg-slate-950 dark:text-white overflow-hidden">
       {/* Sidebar */}
       <Sidebar isOpen={isSidebarOpen} onClose={() => setIsSidebarOpen(false)} />
       
@@ -253,7 +253,7 @@ const DashboardPage: React.FC = () => {
           </div>
 
           {/* Quick Actions */}
-          <section className="bg-gray-800/50 p-4 rounded-xl">
+          <section className="bg-white/70 dark:bg-slate-800/70 backdrop-blur-md shadow-sm p-6 rounded-3xl">
             <h2 className="text-xl font-bold mb-4 text-white">{t('dashboard.quick_actions')}</h2>
             <QuickActions 
               onAddPlant={() => setIsAddModalOpen(true)}
@@ -264,7 +264,7 @@ const DashboardPage: React.FC = () => {
           </section>
           
           {/* Plants List */}
-          <section className="bg-gray-800/50 p-4 rounded-xl">
+          <section className="bg-white/70 dark:bg-slate-800/70 backdrop-blur-md shadow-sm p-6 rounded-3xl">
             <div className="flex justify-between items-center mb-4">
               <h2 className="text-xl font-bold text-white">{t('dashboard.my_plants')}</h2>
               <Link to="/plants" className="text-emerald-400 hover:text-emerald-300 text-sm font-medium">
@@ -312,7 +312,7 @@ const DashboardPage: React.FC = () => {
           </section>
           
           {/* Recent Activity */}
-          <section className="bg-gray-800/50 p-4 rounded-xl">
+          <section className="bg-white/70 dark:bg-slate-800/70 backdrop-blur-md shadow-sm p-6 rounded-3xl">
             <h2 className="text-xl font-bold mb-4 text-white">{t('dashboard.recent_activity')}</h2>
             <div className="space-y-3">
               {plants.length > 0 ? (


### PR DESCRIPTION
## Summary
- restyle stats cards with gradients and animated counters
- redesign quick actions as circular gradient buttons
- use lighter background sections on dashboard

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6847656f385c832aa1ba973dade7c0f7