### PR TITLE
Add dedicated grow creation page

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -12,6 +12,7 @@ import NovaPlantaPage from './pages/NovaPlantaPage';
 import CultivoEtiquetasPage from './pages/CultivoEtiquetasPage';
 import CultivoDetailPage from './pages/CultivoDetailPage';
 import GrowsPage from './pages/GrowsPage';
+import NovoGrowPage from './pages/NovoGrowPage';
 import SettingsPage from './pages/SettingsPage';
 import { PlantProvider } from './contexts/PlantContext';
 import ProtectedRoute from './components/ProtectedRoute';
@@ -58,6 +59,14 @@ const App: React.FC = () => {
             element={
               <ProtectedRoute>
                 <GrowsPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/novo-grow"
+            element={
+              <ProtectedRoute>
+                <NovoGrowPage />
               </ProtectedRoute>
             }
           />

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This project uses [Material UI](https://mui.com/) for its base styling along wit
 
 Run the SQL script in `supabase/diary_entries.sql` on your Supabase project to
 create the `diary_entries` table used by the Netlify functions. This script also
+enables the `uuid-ossp` extension required for `uuid_generate_v4()`.
 
 Run the SQL script in `supabase/grows.sql` to create the `grows` table and add
 `substrate` and `grow_id` columns to `cultivos`.

--- a/pages/GrowsPage.tsx
+++ b/pages/GrowsPage.tsx
@@ -3,15 +3,13 @@ import { Grow } from '../types';
 import { Link, useNavigate } from 'react-router-dom';
 import Button from '../components/Button';
 import ArrowLeftIcon from '../components/icons/ArrowLeftIcon';
+import PlusIcon from '../components/icons/PlusIcon';
 import Toast from '../components/Toast';
 import Loader from "../components/Loader";
 
 export default function GrowsPage() {
   const [grows, setGrows] = useState<Grow[]>([]);
-  const [name, setName] = useState('');
-  const [location, setLocation] = useState('');
   const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
   const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' | 'info' } | null>(null);
   const navigate = useNavigate();
 
@@ -36,24 +34,6 @@ export default function GrowsPage() {
     setGrows(data);
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!name) return;
-    setSaving(true);
-    try {
-      const { addGrow } = await import('../services/growService');
-      await addGrow({ name, location: location || undefined });
-      await refresh();
-      setName('');
-      setLocation('');
-      setToast({ message: 'Grow criado com sucesso!', type: 'success' });
-    } catch (err: any) {
-      setToast({ message: 'Erro ao criar grow: ' + (err.message || err), type: 'error' });
-    } finally {
-      setSaving(false);
-    }
-  };
-
   useEffect(() => {
     if (toast) {
       const t = setTimeout(() => setToast(null), 2500);
@@ -68,9 +48,6 @@ export default function GrowsPage() {
       </div>
     );
   }
-
-  const inputStyle = "w-full px-3 py-2 text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-green-500";
-  const labelStyle = "block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1";
 
   return (
     <div className="max-w-lg mx-auto w-full min-h-screen flex flex-col gap-3 bg-white dark:bg-slate-900 p-2 sm:p-4">
@@ -88,21 +65,15 @@ export default function GrowsPage() {
           <span>&gt;</span>
           <span className="font-bold text-green-700 dark:text-green-300">Grows</span>
         </nav>
+        <div className="flex-1" />
+        <Link to="/novo-grow">
+          <Button variant="primary" size="icon" className="shadow" title="Novo Grow">
+            <PlusIcon className="w-5 h-5" />
+          </Button>
+        </Link>
       </div>
 
-      <h1 className="text-2xl font-extrabold text-green-700 dark:text-green-300 mb-4 text-center">Gerenciar Grows</h1>
-
-      <form onSubmit={handleSubmit} className="space-y-4 bg-white dark:bg-gray-800 p-4 rounded-md shadow">
-        <div>
-          <label htmlFor="growName" className={labelStyle}>Nome</label>
-          <input id="growName" type="text" className={inputStyle} value={name} onChange={e => setName(e.target.value)} required />
-        </div>
-        <div>
-          <label htmlFor="growLocation" className={labelStyle}>Localização (opcional)</label>
-          <input id="growLocation" type="text" className={inputStyle} value={location} onChange={e => setLocation(e.target.value)} />
-        </div>
-        <Button type="submit" variant="primary" loading={saving} disabled={!name}>Salvar Grow</Button>
-      </form>
+      <h1 className="text-2xl font-extrabold text-green-700 dark:text-green-300 mt-4 mb-2">Meus Grows</h1>
 
       <div className="mt-6">
         {grows.length ? (
@@ -115,7 +86,10 @@ export default function GrowsPage() {
             ))}
           </ul>
         ) : (
-          <p className="text-gray-500 dark:text-gray-400 text-center">Nenhum grow cadastrado.</p>
+          <div className="text-gray-400 dark:text-gray-500 text-center py-8">
+            Nenhum grow cadastrado ainda.<br />
+            <Link to="/novo-grow" className="underline text-green-700 dark:text-green-300">Crie sua primeira estufa</Link>
+          </div>
         )}
       </div>
     </div>

--- a/pages/NovoGrowPage.tsx
+++ b/pages/NovoGrowPage.tsx
@@ -1,0 +1,77 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import Button from '../components/Button';
+import ArrowLeftIcon from '../components/icons/ArrowLeftIcon';
+import Toast from '../components/Toast';
+
+export default function NovoGrowPage() {
+  const [name, setName] = useState('');
+  const [location, setLocation] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' | 'info' } | null>(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (toast) {
+      const t = setTimeout(() => setToast(null), 2500);
+      return () => clearTimeout(t);
+    }
+  }, [toast]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name) return;
+    setSaving(true);
+    try {
+      const { addGrow } = await import('../services/growService');
+      await addGrow({ name, location: location || undefined });
+      setToast({ message: 'Grow criado com sucesso!', type: 'success' });
+      setTimeout(() => navigate('/grows'), 1500);
+    } catch (err: any) {
+      setToast({ message: 'Erro ao criar grow: ' + (err.message || err), type: 'error' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const inputStyle = "w-full px-3 py-2 text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-green-500";
+  const labelStyle = "block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1";
+
+  return (
+    <div className="max-w-lg mx-auto w-full min-h-screen flex flex-col gap-3 bg-white dark:bg-slate-900 p-2 sm:p-4">
+      {toast && <Toast message={toast.message} type={toast.type} />}
+      <div className="sticky top-0 z-20 bg-white/80 dark:bg-slate-900/80 flex items-center gap-2 py-2 px-1 sm:px-0 -mx-2 sm:mx-0 backdrop-blur-md mb-2">
+        <button
+          onClick={() => navigate(-1)}
+          className="p-2 rounded-full hover:bg-green-100 dark:hover:bg-green-900 transition focus:outline-none focus:ring-2 focus:ring-green-400"
+          aria-label="Voltar"
+        >
+          <ArrowLeftIcon className="w-7 h-7 text-green-700" />
+        </button>
+        <nav className="text-xs text-gray-500 dark:text-gray-400 flex gap-1">
+          <Link to="/" className="hover:underline">Dashboard</Link>
+          <span>&gt;</span>
+          <Link to="/grows" className="hover:underline">Grows</Link>
+          <span>&gt;</span>
+          <span className="font-bold text-green-700 dark:text-green-300">Novo Grow</span>
+        </nav>
+      </div>
+      <div className="bg-white dark:bg-gray-800 shadow-xl rounded-lg p-4 sm:p-6 flex-1 flex flex-col">
+        <h1 className="text-2xl sm:text-3xl font-extrabold text-green-700 dark:text-green-300 mb-6 text-center">Novo Grow</h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label htmlFor="growName" className={labelStyle}>Nome do Grow</label>
+            <input id="growName" type="text" className={inputStyle} value={name} onChange={e => setName(e.target.value)} required />
+          </div>
+          <div>
+            <label htmlFor="growLocation" className={labelStyle}>Localização (opcional)</label>
+            <input id="growLocation" type="text" className={inputStyle} value={location} onChange={e => setLocation(e.target.value)} />
+          </div>
+          <div className="mt-6 flex justify-center">
+            <Button type="submit" variant="primary" size="lg" loading={saving} disabled={!name}>Salvar Grow</Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add NovoGrowPage for creating grows
- link from GrowsPage with plus button
- wire up /novo-grow route in App

## Testing
- `npm run build` *(fails: vite not found)*
- `npx tsc --noEmit` *(fails: numerous missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68477ce228ac832aa3b1aa1acdbffb58