### PR TITLE
Fix layout responsiveness

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -24,7 +24,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
       {/* Componente do Menu Hamburger */}
       <HamburgerMenu isOpen={isMenuOpen} onClose={toggleMenu} />
 
-      <main className="flex-grow px-4 sm:px-6 lg:px-8 py-6 sm:py-8 bg-slate-950">
+      <main className="flex-grow px-0 py-6 sm:py-8 bg-slate-950">
         {children}
       </main>
 

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
 </script>
 <style>
   body {
+    margin: 0;
     font-family: 'Inter', sans-serif;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;

--- a/pages/GardenStatisticsPage.tsx
+++ b/pages/GardenStatisticsPage.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 
 const GardenStatisticsPage: React.FC = () => {
   return (
-    <div className="container mx-auto p-4 bg-slate-900 min-h-screen text-slate-100 space-y-8">
+    <div className="p-4 bg-slate-900 min-h-screen text-slate-100 space-y-8 w-full">
       <div className="flex justify-between items-center mb-6">
         <h1 className="text-3xl font-bold text-green-400">Estatísticas do Jardim</h1>
         <Link 

--- a/pages/PlantStatisticsPage.tsx
+++ b/pages/PlantStatisticsPage.tsx
@@ -52,7 +52,7 @@ const PlantStatisticsPage: React.FC = () => {
   const operationalStatusLabel = PLANT_OPERATIONAL_STATUS_OPTIONS.find(s => s.value === plant.operationalStatus)?.label || plant.operationalStatus;
 
   return (
-    <div className="container mx-auto p-4 bg-slate-900 min-h-screen text-slate-100 space-y-8">
+    <div className="p-4 bg-slate-900 min-h-screen text-slate-100 space-y-8 w-full">
       <div className="flex justify-between items-center">
         <h1 className="text-3xl font-bold text-green-400">Estatísticas de {plant.name}</h1>
         <Link 


### PR DESCRIPTION
## Summary
- remove browser default body margin
- eliminate horizontal padding from main layout
- allow statistics pages to use full width

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684814575094832a8a3ed69021b747ac