### PR TITLE
Redirect to first cultivo when creating grow

### DIFF
--- a/pages/NovoGrowPage.tsx
+++ b/pages/NovoGrowPage.tsx
@@ -24,9 +24,9 @@ export default function NovoGrowPage() {
     setSaving(true);
     try {
       const { addGrow } = await import('../services/growService');
-      await addGrow({ name, location: location || undefined });
-      setToast({ message: 'Grow criado com sucesso!', type: 'success' });
-      setTimeout(() => navigate('/grows'), 1500);
+      const newGrow = await addGrow({ name, location: location || undefined });
+      setToast({ message: 'Grow criado com sucesso! Cadastre seu primeiro cultivo.', type: 'success' });
+      setTimeout(() => navigate(`/novo-cultivo?growId=${newGrow.id}`), 1500);
     } catch (err: any) {
       setToast({ message: 'Erro ao criar grow: ' + (err.message || err), type: 'error' });
     } finally {


### PR DESCRIPTION
## Summary
- capture new grow id when creating a grow
- redirect user to new cultivo page with grow id so they can add their first cultivo
- toast now invites user to register the first cultivo

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68481b90fd1c832aa145b405c8891188