### PR TITLE
Implement QR scanner page and highlight bottom button

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -14,6 +14,7 @@ import CultivoDetailPage from './pages/CultivoDetailPage';
 import GrowsPage from './pages/GrowsPage';
 import NovoGrowPage from './pages/NovoGrowPage';
 import SettingsPage from './pages/SettingsPage';
+import ScannerPage from './pages/ScannerPage';
 import { PlantProvider } from './contexts/PlantContext';
 import ProtectedRoute from './components/ProtectedRoute';
 
@@ -115,6 +116,14 @@ const App: React.FC = () => {
             element={
               <ProtectedRoute>
                 <AllPlantsPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/scanner"
+            element={
+              <ProtectedRoute>
+                <ScannerPage />
               </ProtectedRoute>
             }
           />

--- a/components/BottomNavigation.tsx
+++ b/components/BottomNavigation.tsx
@@ -23,9 +23,12 @@ const BottomNavigation: React.FC = () => {
     { label: t('sidebar.settings'), path: '/settings', icon: Cog6ToothIcon },
   ];
 
+  const scannerItem = navItems.find(item => item.path === '/scanner');
+  const otherItems = navItems.filter(item => item.path !== '/scanner');
+
   return (
-    <nav className="fixed bottom-0 left-0 right-0 bg-slate-900/90 backdrop-blur-md border-t border-slate-700 text-slate-200 flex justify-around py-2 md:hidden z-50">
-      {navItems.map(({ label, path, icon: Icon }) => {
+    <nav className="fixed bottom-0 left-0 right-0 bg-slate-900/90 backdrop-blur-md border-t border-slate-700 text-slate-200 flex justify-around py-2 md:hidden z-50 relative">
+      {otherItems.map(({ label, path, icon: Icon }) => {
         const isActive = location.pathname === path;
         return (
           <Link
@@ -38,6 +41,17 @@ const BottomNavigation: React.FC = () => {
           </Link>
         );
       })}
+      {scannerItem && (() => {
+        const ScannerIcon = scannerItem.icon;
+        return (
+          <Link
+            to={scannerItem.path}
+            className="absolute left-1/2 -top-6 -translate-x-1/2 bg-emerald-500 text-white rounded-full p-3 shadow-lg"
+          >
+            <ScannerIcon className="w-7 h-7" />
+          </Link>
+        );
+      })()}
     </nav>
   );
 };

--- a/pages/ScannerPage.tsx
+++ b/pages/ScannerPage.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import Sidebar from '../components/Sidebar';
+import Header from '../components/Header';
+import QrCodeScanner from '../components/QrCodeScanner';
+import { Plant } from '../types';
+
+const ScannerPage: React.FC = () => {
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const [scanError, setScanError] = useState<string | null>(null);
+  const navigate = useNavigate();
+  const { t } = useTranslation();
+
+  const handleScanSuccess = (plant: Plant) => {
+    navigate(`/plant/${plant.id}`);
+  };
+
+  const handleScanError = (message: string) => {
+    setScanError(message);
+  };
+
+  return (
+    <div className="flex h-screen bg-gray-900 text-white overflow-hidden">
+      <Sidebar isOpen={isSidebarOpen} onClose={() => setIsSidebarOpen(false)} />
+      <div className="flex-1 flex flex-col overflow-hidden">
+        <Header
+          title={t('header.scan_qr')}
+          onOpenSidebar={() => setIsSidebarOpen(true)}
+          onOpenAddModal={() => navigate('/nova-planta')}
+          onOpenScannerModal={() => {}}
+        />
+        <main className="flex-1 overflow-y-auto p-4 md:p-6 flex flex-col items-center">
+          {scanError && (
+            <div className="mb-4 p-3 bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300 rounded-lg">
+              {scanError}
+            </div>
+          )}
+          <QrCodeScanner onScanSuccess={handleScanSuccess} onScanError={handleScanError} />
+        </main>
+      </div>
+    </div>
+  );
+};
+
+export default ScannerPage;


### PR DESCRIPTION
## Summary
- create new ScannerPage and route
- highlight scanner button in bottom navigation
- add route to load scanner page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684827d68268832a8c06dc8aefa545fc