### PR TITLE
Fix bottom navigation visibility

### DIFF
--- a/pages/AllPlantsPage.tsx
+++ b/pages/AllPlantsPage.tsx
@@ -62,7 +62,7 @@ const AllPlantsPage: React.FC = () => {
 
   return (
     <>
-    <div className="flex h-screen bg-gray-900 text-white overflow-hidden">
+    <div className="flex min-h-screen bg-gray-900 text-white overflow-y-auto">
       <Sidebar isOpen={isSidebarOpen} onClose={() => setIsSidebarOpen(false)} />
       <div className="flex-1 flex flex-col overflow-hidden">
         <Header

--- a/pages/DashboardPage.tsx
+++ b/pages/DashboardPage.tsx
@@ -187,7 +187,7 @@ const DashboardPage: React.FC = () => {
   const selectStyle = "mt-1 block w-full px-3 py-2.5 bg-[#EAEAEA] dark:bg-slate-700 border border-gray-300 dark:border-slate-600 text-[#3E3E3E] dark:text-slate-100 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[#7AC943] focus:border-[#7AC943] sm:text-sm transition-colors";
 
   return (
-    <div className="flex h-screen bg-gray-50 text-gray-900 dark:bg-slate-950 dark:text-white overflow-hidden">
+    <div className="flex min-h-screen bg-gray-50 text-gray-900 dark:bg-slate-950 dark:text-white overflow-y-auto">
       {/* Sidebar */}
       <Sidebar isOpen={isSidebarOpen} onClose={() => setIsSidebarOpen(false)} />
       

--- a/pages/ScannerPage.tsx
+++ b/pages/ScannerPage.tsx
@@ -21,7 +21,7 @@ const ScannerPage: React.FC = () => {
   };
 
   return (
-    <div className="flex h-screen bg-gray-900 text-white overflow-hidden">
+    <div className="flex min-h-screen bg-gray-900 text-white overflow-y-auto">
       <Sidebar isOpen={isSidebarOpen} onClose={() => setIsSidebarOpen(false)} />
       <div className="flex-1 flex flex-col overflow-hidden">
         <Header

--- a/pages/SettingsPage.tsx
+++ b/pages/SettingsPage.tsx
@@ -9,7 +9,7 @@ const SettingsPage: React.FC = () => {
   const { t } = useTranslation();
 
   return (
-    <div className="flex h-screen bg-gray-900 text-white overflow-hidden">
+    <div className="flex min-h-screen bg-gray-900 text-white overflow-y-auto">
       <Sidebar isOpen={isSidebarOpen} onClose={() => setIsSidebarOpen(false)} />
       <div className="flex-1 flex flex-col overflow-hidden">
         <Header


### PR DESCRIPTION
## Summary
- use `min-h-screen` in pages so bottom nav stays visible
- keep QR label padding changes

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684829fe397c832ab418fcf94d96a0fa