### PR TITLE
Fix mobile bottom nav safe area

### DIFF
--- a/components/BottomNavigation.tsx
+++ b/components/BottomNavigation.tsx
@@ -27,7 +27,10 @@ const BottomNavigation: React.FC = () => {
   const otherItems = navItems.filter(item => item.path !== '/scanner');
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 bg-slate-900/90 backdrop-blur-md border-t border-slate-700 text-slate-200 flex justify-around py-2 md:hidden z-50 relative">
+    <nav
+      className="fixed bottom-0 left-0 right-0 bg-slate-900/90 backdrop-blur-md border-t border-slate-700 text-slate-200 flex justify-around md:hidden z-50 relative pt-2"
+      style={{ paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 0.5rem)' }}
+    >
       {otherItems.map(({ label, path, icon: Icon }) => {
         const isActive = location.pathname === path;
         return (


### PR DESCRIPTION
## Summary
- adjust mobile BottomNavigation padding to respect safe area insets

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68483f17f7b0832a94030df6d04e2f5e