### PR TITLE
Fix mobile bottom nav safe area

### DIFF
--- a/components/BottomNavigation.tsx
+++ b/components/BottomNavigation.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { NavLink, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
   HomeIcon,
@@ -11,7 +11,6 @@ import LeafIcon from './icons/LeafIcon';
 import QrCodeIcon from './icons/QrCodeIcon';
 
 const BottomNavigation: React.FC = () => {
-  const location = useLocation();
   const { t } = useTranslation();
 
   const navItems = [
@@ -27,20 +26,22 @@ const BottomNavigation: React.FC = () => {
   const otherItems = navItems.filter(item => item.path !== '/scanner');
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 bg-slate-900/90 backdrop-blur-md border-t border-slate-700 text-slate-200 flex justify-around py-2 md:hidden z-50 relative">
-      {otherItems.map(({ label, path, icon: Icon }) => {
-        const isActive = location.pathname === path;
-        return (
-          <Link
-            key={path}
-            to={path}
-            className={`flex flex-col items-center text-xs flex-1 py-2 ${isActive ? 'text-green-400' : 'text-slate-300'}`}
-          >
-            <Icon className="w-6 h-6" />
-            <span className="mt-1">{label}</span>
-          </Link>
-        );
-      })}
+    <nav
+      className="fixed bottom-0 left-0 right-0 bg-slate-900/90 backdrop-blur-md border-t border-slate-700 text-slate-200 flex justify-around md:hidden z-50 relative pt-2"
+      style={{ paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 0.5rem)' }}
+    >
+      {otherItems.map(({ label, path, icon: Icon }) => (
+        <NavLink
+          key={path}
+          to={path}
+          className={({ isActive }) =>
+            `flex flex-col items-center text-xs flex-1 py-2 ${isActive ? 'text-green-400' : 'text-slate-300'}`
+          }
+        >
+          <Icon className="w-6 h-6" />
+          <span className="mt-1">{label}</span>
+        </NavLink>
+      ))}
       {scannerItem && (() => {
         const ScannerIcon = scannerItem.icon;
         return (

--- a/components/BottomNavigation.tsx
+++ b/components/BottomNavigation.tsx
@@ -27,6 +27,7 @@ const BottomNavigation: React.FC = () => {
 
   return (
     <nav
+      role="navigation"
       className="fixed bottom-0 left-0 right-0 bg-slate-900/90 backdrop-blur-md border-t border-slate-700 text-slate-200 flex justify-around md:hidden z-50 relative pt-2"
       style={{ paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 0.5rem)' }}
     >
@@ -37,6 +38,7 @@ const BottomNavigation: React.FC = () => {
           className={({ isActive }) =>
             `flex flex-col items-center text-xs flex-1 py-2 ${isActive ? 'text-green-400' : 'text-slate-300'}`
           }
+          aria-label={label}
         >
           <Icon className="w-6 h-6" />
           <span className="mt-1">{label}</span>
@@ -48,6 +50,7 @@ const BottomNavigation: React.FC = () => {
           <Link
             to={scannerItem.path}
             className="absolute left-1/2 -top-6 -translate-x-1/2 bg-emerald-500 text-white rounded-full p-3 shadow-lg"
+            aria-label={scannerItem.label}
           >
             <ScannerIcon className="w-7 h-7" />
           </Link>


### PR DESCRIPTION
## Summary
- adjust mobile BottomNavigation padding to respect safe area insets
- use `NavLink` so active nav items highlight correctly on mobile

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68483f17f7b0832a94030df6d04e2f5e