### PR TITLE
Improve dashboard mobile nav layering

### DIFF
--- a/components/BottomNavigation.tsx
+++ b/components/BottomNavigation.tsx
@@ -28,7 +28,7 @@ const BottomNavigation: React.FC = () => {
   return (
     <nav
       role="navigation"
-      className="fixed bottom-0 left-0 right-0 bg-slate-900/90 backdrop-blur-md border-t border-slate-700 text-slate-200 flex justify-around md:hidden z-50 relative pt-2"
+      className="fixed bottom-0 left-0 right-0 bg-slate-900/90 backdrop-blur-md border-t border-slate-700 text-slate-200 flex justify-around md:hidden z-[999] relative pt-2 pointer-events-auto"
       style={{ paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 0.5rem)' }}
     >
       {otherItems.map(({ label, path, icon: Icon }) => (

--- a/components/QuickActions.tsx
+++ b/components/QuickActions.tsx
@@ -46,7 +46,7 @@ const QuickActions: React.FC<QuickActionsProps> = ({
 }) => {
   const { t } = useTranslation();
   return (
-    <div className="grid grid-cols-2 md:grid-cols-5 gap-6">
+    <div className="grid grid-cols-3 sm:grid-cols-5 gap-6 justify-items-center max-w-md mx-auto">
       <QuickAction
         title={t('header.add_plant')}
         icon={<MdAdd size={32} />}


### PR DESCRIPTION
## Summary
- bump bottom nav z-index so it stays visible
- center quick action grid on dashboard

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684870210a00832a890f97a832091623