### PR TITLE
Fix mobile bottom navigation visibility

### DIFF
--- a/components/BottomNavigation.tsx
+++ b/components/BottomNavigation.tsx
@@ -28,7 +28,7 @@ const BottomNavigation: React.FC = () => {
   return (
     <nav
       role="navigation"
-      className="fixed bottom-0 left-0 right-0 bg-slate-900/90 backdrop-blur-md border-t border-slate-700 text-slate-200 flex justify-around md:hidden z-[999] relative pt-2 pointer-events-auto"
+      className="fixed bottom-0 left-0 right-0 bg-slate-900/90 backdrop-blur-md border-t border-slate-700 text-slate-200 flex justify-around md:hidden z-[1100] relative pt-2 pointer-events-auto"
       style={{ paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 0.5rem)' }}
     >
       {otherItems.map(({ label, path, icon: Icon }) => (

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -25,16 +25,16 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
       {/* Componente do Menu Hamburger */}
       <HamburgerMenu isOpen={isMenuOpen} onClose={toggleMenu} />
 
-      <main className="flex-grow px-0 py-6 sm:py-8 bg-slate-950 pb-20 md:pb-8">
+      <main className="flex-grow px-0 py-6 sm:py-8 bg-slate-950 pb-24 md:pb-8">
         {children}
       </main>
+
+      {/* Navegação inferior para dispositivos móveis */}
+      <BottomNavigation />
 
       <footer className="bg-slate-800 text-slate-400 text-center py-6 text-sm border-t border-slate-700 transition-colors duration-300">
         <p>&copy; {new Date().getFullYear()} {APP_NAME}. Todos os direitos reservados.</p>
       </footer>
-
-      {/* Navegação inferior para dispositivos móveis */}
-      <BottomNavigation />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- keep mobile bottom bar on top of other content
- add extra padding for main content

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684878b58258832a9c7dc0d2cb353832