### PR TITLE
Implement QR grow options

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -13,6 +13,7 @@ import CultivoEtiquetasPage from './pages/CultivoEtiquetasPage';
 import CultivoDetailPage from './pages/CultivoDetailPage';
 import GrowsPage from './pages/GrowsPage';
 import NovoGrowPage from './pages/NovoGrowPage';
+import GrowDetailPage from './pages/GrowDetailPage';
 import SettingsPage from './pages/SettingsPage';
 import ScannerPage from './pages/ScannerPage';
 import { PlantProvider } from './contexts/PlantContext';
@@ -68,6 +69,14 @@ const App: React.FC = () => {
             element={
               <ProtectedRoute>
                 <NovoGrowPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/grow/:growId"
+            element={
+              <ProtectedRoute>
+                <GrowDetailPage />
               </ProtectedRoute>
             }
           />

--- a/components/DiaryEntryForm.tsx
+++ b/components/DiaryEntryForm.tsx
@@ -22,6 +22,13 @@ const DiaryEntryForm: React.FC<DiaryEntryFormProps> = ({ plantCurrentStage, onSu
     ph: initialData?.ph || undefined,
     temperature: initialData?.temperature || undefined,
     humidity: initialData?.humidity || undefined,
+    wateringVolume: initialData?.wateringVolume || undefined,
+    wateringType: initialData?.wateringType || '',
+    fertilizationType: initialData?.fertilizationType || '',
+    fertilizationConcentration: initialData?.fertilizationConcentration || undefined,
+    photoperiod: initialData?.photoperiod || '',
+    sprayProduct: initialData?.sprayProduct || '',
+    sprayAmount: initialData?.sprayAmount || undefined,
     symptoms: initialData?.symptoms || '',
     actionsTaken: initialData?.actionsTaken || '',
     aiOverallDiagnosis: initialData?.aiOverallDiagnosis || '',
@@ -87,13 +94,20 @@ const DiaryEntryForm: React.FC<DiaryEntryFormProps> = ({ plantCurrentStage, onSu
         return;
     }
     const dataToSubmit: NewDiaryEntryData = {
-      stage: formData.stage, 
+      stage: formData.stage,
       notes: formData.notes,
       heightCm: formData.heightCm,
       ec: formData.ec,
       ph: formData.ph,
       temperature: formData.temperature,
       humidity: formData.humidity,
+      wateringVolume: formData.wateringVolume,
+      wateringType: formData.wateringType,
+      fertilizationType: formData.fertilizationType,
+      fertilizationConcentration: formData.fertilizationConcentration,
+      photoperiod: formData.photoperiod,
+      sprayProduct: formData.sprayProduct,
+      sprayAmount: formData.sprayAmount,
       symptoms: formData.symptoms,
       actionsTaken: formData.actionsTaken,
       aiOverallDiagnosis: formData.aiOverallDiagnosis,
@@ -135,6 +149,34 @@ const DiaryEntryForm: React.FC<DiaryEntryFormProps> = ({ plantCurrentStage, onSu
         <div>
           <label htmlFor="humidity" className={labelClass}>Umidade Ambiente (%)</label>
           <input type="number" name="humidity" id="humidity" value={formData.humidity || ''} onChange={handleChange} step="0.1" className={formFieldClass} />
+        </div>
+        <div>
+          <label htmlFor="wateringVolume" className={labelClass}>Rega (L)</label>
+          <input type="number" name="wateringVolume" id="wateringVolume" value={formData.wateringVolume || ''} onChange={handleChange} step="0.1" className={formFieldClass} />
+        </div>
+        <div>
+          <label htmlFor="wateringType" className={labelClass}>Tipo de Água</label>
+          <input type="text" name="wateringType" id="wateringType" value={formData.wateringType || ''} onChange={handleChange} className={formFieldClass} />
+        </div>
+        <div>
+          <label htmlFor="fertilizationType" className={labelClass}>Fertilizante</label>
+          <input type="text" name="fertilizationType" id="fertilizationType" value={formData.fertilizationType || ''} onChange={handleChange} className={formFieldClass} />
+        </div>
+        <div>
+          <label htmlFor="fertilizationConcentration" className={labelClass}>Concentração</label>
+          <input type="number" name="fertilizationConcentration" id="fertilizationConcentration" value={formData.fertilizationConcentration || ''} onChange={handleChange} step="0.01" className={formFieldClass} />
+        </div>
+        <div>
+          <label htmlFor="photoperiod" className={labelClass}>Fotoperíodo</label>
+          <input type="text" name="photoperiod" id="photoperiod" value={formData.photoperiod || ''} onChange={handleChange} className={formFieldClass} />
+        </div>
+        <div>
+          <label htmlFor="sprayProduct" className={labelClass}>Produto de Pulverização</label>
+          <input type="text" name="sprayProduct" id="sprayProduct" value={formData.sprayProduct || ''} onChange={handleChange} className={formFieldClass} />
+        </div>
+        <div>
+          <label htmlFor="sprayAmount" className={labelClass}>Quantidade Pulverizada (mL)</label>
+          <input type="number" name="sprayAmount" id="sprayAmount" value={formData.sprayAmount || ''} onChange={handleChange} step="0.1" className={formFieldClass} />
         </div>
       </div>
 

--- a/components/DiaryEntryItem.tsx
+++ b/components/DiaryEntryItem.tsx
@@ -85,6 +85,13 @@ const DiaryEntryItem: React.FC<DiaryEntryItemProps> = ({ entry }) => {
             <DetailItem label="pH" value={entry.ph} />
             <DetailItem label="Temp." value={entry.temperature} unit="°C" />
             <DetailItem label="Umidade" value={entry.humidity} unit="%" />
+            <DetailItem label="Rega" value={entry.wateringVolume} unit="L" />
+            <DetailItem label="Tipo de Água" value={entry.wateringType} />
+            <DetailItem label="Fertilizante" value={entry.fertilizationType} />
+            <DetailItem label="Concentração" value={entry.fertilizationConcentration} />
+            <DetailItem label="Fotoperíodo" value={entry.photoperiod} />
+            <DetailItem label="Pulverização" value={entry.sprayProduct} />
+            <DetailItem label="Qtde Pulverizada" value={entry.sprayAmount} unit="mL" />
           </div>
 
           {entry.aiOverallDiagnosis && (

--- a/components/GrowQrCodeDisplay.tsx
+++ b/components/GrowQrCodeDisplay.tsx
@@ -1,0 +1,103 @@
+import React, { useState } from 'react';
+import { Grow } from '../types';
+import ClipboardIcon from './icons/ClipboardIcon';
+import DownloadIcon from './icons/DownloadIcon';
+import { QRCodeSVG } from 'qrcode.react';
+import QRCode from 'qrcode';
+
+interface GrowQrCodeDisplayProps {
+  grow: Grow;
+}
+
+const GrowQrCodeDisplay: React.FC<GrowQrCodeDisplayProps> = ({ grow }) => {
+  const [copied, setCopied] = useState(false);
+  const qrSize = 128;
+  const qrValue = grow.qrCodeValue || grow.id;
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(qrValue).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  const handleDownloadSVG = async () => {
+    const svgWidth = 220;
+    const svgHeight = 220;
+    const qrDisplaySize = 140;
+    const textFont = 'Inter, sans-serif';
+    const nameSVG = grow.name.length > 25 ? grow.name.substring(0,22) + '...' : grow.name;
+
+    try {
+      const qrSvgStringGenerated = await QRCode.toString(qrValue, {
+        type: 'svg',
+        errorCorrectionLevel: 'Q',
+        margin: 1,
+        width: qrDisplaySize,
+        color: { dark: '#000000FF', light: '#FFFFFFFF' },
+      });
+      const cleanQrSvgString = qrSvgStringGenerated
+        .replace(/<\?xml.*?\?>\s*/, '')
+        .replace(/<!DOCTYPE.*?>\s*/, '');
+
+      const svgContent = `
+        <svg xmlns="http://www.w3.org/2000/svg" width="${svgWidth}" height="${svgHeight}" viewBox="0 0 ${svgWidth} ${svgHeight}">
+          <rect width="100%" height="100%" fill="white"/>
+          <style>
+            .label-text { font-family: ${textFont}; fill: black; }
+            .name { font-size: 18px; font-weight: bold; }
+            .qr-value { font-size: 9px; font-family: monospace; }
+          </style>
+          <text x="${svgWidth / 2}" y="30" text-anchor="middle" class="label-text name">${nameSVG}</text>
+          <g transform="translate(${(svgWidth - qrDisplaySize) / 2}, 40)">
+            ${cleanQrSvgString}
+          </g>
+          <text x="${svgWidth / 2}" y="${40 + qrDisplaySize + 20}" text-anchor="middle" class="label-text qr-value">${qrValue}</text>
+          <text x="${svgWidth / 2}" y="${40 + qrDisplaySize + 35}" text-anchor="middle" class="label-text qr-value" style="font-size:8px;">BuddyScan</text>
+        </svg>
+      `;
+
+      const blob = new Blob([svgContent], { type: 'image/svg+xml' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `buddyscan_grow_${grow.name.replace(/\s+/g, '_')}.svg`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error('Falha ao gerar QR code SVG para download:', err);
+      alert('Erro ao gerar QR code para download. Verifique o console.');
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center p-4 border border-gray-200 dark:border-slate-700 rounded-lg bg-white dark:bg-slate-800 shadow-md w-full max-w-[220px] mx-auto text-center transition-colors duration-300 space-y-3">
+      <div className="font-bold text-lg text-[#7AC943] break-words w-full leading-tight">{grow.name}</div>
+      {grow.location && (
+        <div className="text-sm text-gray-600 dark:text-slate-300 w-full truncate">{grow.location}</div>
+      )}
+      <div className="w-full flex items-center justify-center p-1 bg-white rounded-sm" style={{ maxWidth: qrSize + 8, maxHeight: qrSize + 8 }}>
+        <QRCodeSVG value={qrValue} size={qrSize} bgColor="#ffffff" fgColor="#000000" level="Q" includeMargin={false} />
+      </div>
+      <button
+        onClick={handleCopy}
+        className="text-xs text-[#7AC943] hover:text-green-500 flex items-center justify-center gap-1.5 transition-colors duration-150 font-medium py-1 px-2 rounded-md hover:bg-green-50 dark:hover:bg-slate-700 w-full max-w-[150px]"
+      >
+        <ClipboardIcon className="w-3.5 h-3.5" />
+        {copied ? 'ID Copiado!' : 'Copiar ID'}
+      </button>
+      <p className="text-[10px] text-gray-400 dark:text-slate-500 break-all leading-tight w-full px-1">{qrValue}</p>
+      <button
+        onClick={handleDownloadSVG}
+        className="w-full max-w-[180px] mt-2 flex items-center justify-center gap-2 bg-sky-500 hover:bg-sky-600 text-white text-xs font-semibold py-2 px-3 rounded-lg shadow hover:shadow-md transition-all duration-150 ease-in-out focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-opacity-75"
+      >
+        <DownloadIcon className="w-4 h-4" />
+        Baixar Etiqueta (SVG)
+      </button>
+    </div>
+  );
+};
+
+export default GrowQrCodeDisplay;

--- a/docs/GESTAO_ESPACOS_PLANTIOS_PT_BR.md
+++ b/docs/GESTAO_ESPACOS_PLANTIOS_PT_BR.md
@@ -5,7 +5,7 @@ Este documento detalha como criar e gerenciar **espaços físicos** e **plantios
 ## 1. Espaços Físicos
 - Exemplos de espaços: **estufas** e **growrooms**.
 - Cadastro simples com **nome**, **localização** e **capacidade**.
-- Cada espaço gera um **QR Code** exclusivo para acesso imediato.
+- O QR Code do espaço é gerado automaticamente e pode ser baixado na página de detalhes.
 
 ## 2. Plantios dentro do Espaço
 - Cada espaço possui múltiplos **plantios** cadastrados individualmente.
@@ -22,12 +22,13 @@ Este documento detalha como criar e gerenciar **espaços físicos** e **plantios
 - Botões visíveis permitem **Selecionar Plantio** ou **Registrar Ação em Massa**.
 
 ## 5. Registro em Massa
-- Selecionando todo um plantio, o usuário registra ações de forma simplificada para todas as plantas:
+- Selecionando todo um plantio, o usuário registra ações de forma simplificada para todas as plantas. O formulário inclui:
   - **Rega**: volume e tipo de água ou solução.
   - **Fertilização**: tipo de nutriente e concentração.
   - **Mudança de fotoperíodo**: 12/12, 18/6 ou valor personalizado.
   - **Pulverização preventiva**: produto e quantidade aplicada.
 - Após o registro em massa, cada planta recebe automaticamente seu diário individual.
+ - Também é possível registrar notas rápidas para todas as plantas de uma vez.
 
 ## 6. Registro Individual
 - Cada planta também possui seu próprio **QR Code**.

--- a/netlify/functions/addGrow.ts
+++ b/netlify/functions/addGrow.ts
@@ -1,5 +1,6 @@
 import { Handler } from '@netlify/functions';
 import { createClient } from '@supabase/supabase-js';
+import { v4 as uuidv4 } from 'uuid';
 import { debugLog } from './utils';
 
 const supabase = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
@@ -17,13 +18,14 @@ export const handler: Handler = async (event, context) => {
     return { statusCode: 400, body: JSON.stringify({ error: 'Corpo da requisição ausente.' }) };
   }
   try {
-    const { name, location } = JSON.parse(event.body);
+    const { name, location, capacity } = JSON.parse(event.body);
     if (!name) {
       return { statusCode: 400, body: JSON.stringify({ error: 'Nome obrigatório.' }) };
     }
+    const qrCodeValue = uuidv4();
     const { data, error } = await supabase
       .from('grows')
-      .insert([{ name, location, user_id: user.sub }])
+      .insert([{ name, location, capacity, qr_code_value: qrCodeValue, user_id: user.sub }])
       .select()
       .single();
     debugLog('[addGrow] Insert result:', { data, error });

--- a/netlify/functions/addMassDiaryEntry.ts
+++ b/netlify/functions/addMassDiaryEntry.ts
@@ -1,0 +1,64 @@
+import { Handler } from '@netlify/functions';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+
+function camelToSnake(obj: any) {
+  const newObj: any = {};
+  for (const key in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      const snakeKey = key.replace(/[A-Z]/g, (l) => `_${l.toLowerCase()}`);
+      newObj[snakeKey] = obj[key];
+    }
+  }
+  return newObj;
+}
+
+export const handler: Handler = async (event, context) => {
+  const { user } = context.clientContext || {};
+  if (!user || !user.sub) {
+    return { statusCode: 401, body: JSON.stringify({ error: 'Usuário não autenticado.' }) };
+  }
+  const userId = user.sub;
+
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, body: JSON.stringify({ error: 'Método não permitido. Use POST.' }), headers: { Allow: 'POST' } };
+  }
+  if (!event.body) {
+    return { statusCode: 400, body: JSON.stringify({ error: 'Corpo da requisição ausente.' }) };
+  }
+
+  try {
+    const body = JSON.parse(event.body);
+    if (!body.cultivoId) {
+      return { statusCode: 400, body: JSON.stringify({ error: 'cultivoId é obrigatório.' }) };
+    }
+    const entryData = camelToSnake(body.entry || {});
+    entryData.user_id = userId;
+    delete entryData.id;
+
+    const { data: plants, error: plantError } = await supabase
+      .from('plants')
+      .select('id')
+      .eq('cultivo_id', body.cultivoId)
+      .eq('user_id', userId);
+
+    if (plantError) {
+      return { statusCode: 500, body: JSON.stringify({ error: 'Erro ao buscar plantas', details: plantError.message }) };
+    }
+
+    if (!plants || plants.length === 0) {
+      return { statusCode: 400, body: JSON.stringify({ error: 'Nenhuma planta encontrada para o cultivo' }) };
+    }
+
+    const entries = plants.map(p => ({ ...entryData, plant_id: p.id }));
+
+    const { error } = await supabase.from('diary_entries').insert(entries);
+    if (error) {
+      return { statusCode: 500, body: JSON.stringify({ error: 'Erro ao adicionar entradas.', details: error.message }) };
+    }
+    return { statusCode: 201, body: JSON.stringify({ count: entries.length }) };
+  } catch (e: any) {
+    return { statusCode: 500, body: JSON.stringify({ error: 'Erro inesperado no servidor.', details: e.message }) };
+  }
+};

--- a/pages/DashboardPage.tsx
+++ b/pages/DashboardPage.tsx
@@ -17,7 +17,7 @@ import PlantCardSkeleton from '../components/PlantCardSkeleton';
 import Modal from '../components/Modal';
 import Button from '../components/Button';
 import ImageUpload from '../components/ImageUpload';
-import QrCodeScanner from '../components/QrCodeScanner';
+import QrCodeScanner, { ScanResult } from '../components/QrCodeScanner';
 import { usePlantContext } from '../contexts/PlantContext';
 import { useAuth } from '../contexts/AuthContext';
 import { Plant, PlantStage, PlantHealthStatus, PlantOperationalStatus, NewPlantData, DiaryEntry } from '../types';
@@ -154,8 +154,12 @@ const DashboardPage: React.FC = () => {
     setIsAddingPlant(false);
   };
 
-  const handleScanSuccess = (plant: Plant) => {
-    navigate(`/plant/${plant.id}`);
+  const handleScanSuccess = (result: ScanResult) => {
+    if (result.type === 'plant' && result.plant) {
+      navigate(`/plant/${result.plant.id}`);
+    } else if (result.type === 'grow' && result.grow) {
+      navigate(`/grow/${result.grow.id}`);
+    }
   };
 
   const handleScanError = (msg: string) => {
@@ -374,7 +378,7 @@ const DashboardPage: React.FC = () => {
         {scannerError && (
           <Typography color="error" sx={{ mb: 2 }}>{scannerError}</Typography>
         )}
-        <QrCodeScanner onScanSuccess={handleScanSuccess} onScanError={handleScanError} />
+        <QrCodeScanner onScanSuccess={handleScanSuccess} onScanError={handleScanError} scanType="auto" />
       </Modal>
     </Box>
   );

--- a/pages/GrowDetailPage.tsx
+++ b/pages/GrowDetailPage.tsx
@@ -1,0 +1,232 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, Link, useNavigate } from 'react-router-dom';
+import { Grow, Cultivo, PlantStage } from '../types';
+import ArrowLeftIcon from '../components/icons/ArrowLeftIcon';
+import PlusIcon from '../components/icons/PlusIcon';
+import Button from '../components/Button';
+import Loader from '../components/Loader';
+import Toast from '../components/Toast';
+import Modal from '../components/Modal';
+import GrowQrCodeDisplay from '../components/GrowQrCodeDisplay';
+import { addMassDiaryEntry } from '../services/plantService';
+
+export default function GrowDetailPage() {
+  const { growId } = useParams<{ growId: string }>();
+  const navigate = useNavigate();
+  const [grow, setGrow] = useState<Grow | null>(null);
+  const [cultivos, setCultivos] = useState<Cultivo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' | 'info' } | null>(null);
+  const [showQrModal, setShowQrModal] = useState(false);
+  const [selectedCultivo, setSelectedCultivo] = useState<Cultivo | null>(null);
+  const [showMassModal, setShowMassModal] = useState(false);
+  const [massNotes, setMassNotes] = useState('');
+  const [massWateringVolume, setMassWateringVolume] = useState('');
+  const [massWateringType, setMassWateringType] = useState('');
+  const [massFertilizationType, setMassFertilizationType] = useState('');
+  const [massFertilizationConcentration, setMassFertilizationConcentration] = useState('');
+  const [massPhotoperiod, setMassPhotoperiod] = useState('');
+  const [massSprayProduct, setMassSprayProduct] = useState('');
+  const [massSprayAmount, setMassSprayAmount] = useState('');
+
+  useEffect(() => {
+    async function fetchData() {
+      try {
+        const { getGrows } = await import('../services/growService');
+        const { getCultivos } = await import('../services/cultivoService');
+        const [growList, cultivosList] = await Promise.all([getGrows(), getCultivos()]);
+        setGrow(growList.find(g => g.id === growId) || null);
+        setCultivos(cultivosList.filter(c => c.growId === growId));
+      } catch (err) {
+        setToast({ message: 'Erro ao carregar dados', type: 'error' });
+      } finally {
+        setLoading(false);
+      }
+    }
+    if (growId) fetchData();
+  }, [growId]);
+
+  const openMassModal = (cultivo: Cultivo) => {
+    setSelectedCultivo(cultivo);
+    setShowMassModal(true);
+    setMassNotes('');
+    setMassWateringVolume('');
+    setMassWateringType('');
+    setMassFertilizationType('');
+    setMassFertilizationConcentration('');
+    setMassPhotoperiod('');
+    setMassSprayProduct('');
+    setMassSprayAmount('');
+  };
+
+  const handleMassRegister = async () => {
+    if (!selectedCultivo) return;
+    try {
+      await addMassDiaryEntry(selectedCultivo.id, {
+        notes: massNotes || undefined,
+        wateringVolume: massWateringVolume ? Number(massWateringVolume) : undefined,
+        wateringType: massWateringType || undefined,
+        fertilizationType: massFertilizationType || undefined,
+        fertilizationConcentration: massFertilizationConcentration ? Number(massFertilizationConcentration) : undefined,
+        photoperiod: massPhotoperiod || undefined,
+        sprayProduct: massSprayProduct || undefined,
+        sprayAmount: massSprayAmount ? Number(massSprayAmount) : undefined,
+        stage: PlantStage.VEGETATIVE,
+      });
+      setToast({ message: 'Ação registrada em massa com sucesso', type: 'success' });
+    } catch (e: any) {
+      setToast({ message: e.message || 'Erro ao registrar ação em massa', type: 'error' });
+    } finally {
+      setShowMassModal(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-full p-6">
+        <Loader message="Carregando espaço..." size="md" />
+      </div>
+    );
+  }
+
+  if (!grow) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-full p-6">
+        Espaço não encontrado
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-lg mx-auto w-full min-h-full flex flex-col gap-3 bg-white dark:bg-slate-900 p-2 sm:p-4">
+      {toast && <Toast message={toast.message} type={toast.type} />}
+      <div className="sticky top-0 z-20 bg-white/80 dark:bg-slate-900/80 flex items-center gap-2 py-2 px-1 sm:px-0 -mx-2 sm:mx-0 backdrop-blur-md mb-2">
+        <button
+          onClick={() => navigate(-1)}
+          className="p-2 rounded-full hover:bg-green-100 dark:hover:bg-green-900 transition focus:outline-none focus:ring-2 focus:ring-green-400"
+          aria-label="Voltar"
+        >
+          <ArrowLeftIcon className="w-7 h-7 text-green-700" />
+        </button>
+        <nav className="text-xs text-gray-500 dark:text-gray-400 flex gap-1">
+          <Link to="/" className="hover:underline">Dashboard</Link>
+          <span>&gt;</span>
+          <Link to="/grows" className="hover:underline">Grows</Link>
+          <span>&gt;</span>
+          <span className="font-bold text-green-700 dark:text-green-300">{grow.name}</span>
+        </nav>
+        <div className="flex-1" />
+        <Link to={`/novo-cultivo?growId=${grow.id}`}>
+          <Button variant="primary" size="icon" className="shadow" title="Novo Plantio">
+            <PlusIcon className="w-5 h-5" />
+          </Button>
+        </Link>
+      </div>
+
+      <h1 className="text-2xl font-extrabold text-green-700 dark:text-green-300 mt-2 mb-2">{grow.name}</h1>
+      {grow.location && <p className="text-sm text-gray-500 dark:text-gray-400">{grow.location}</p>}
+      {grow.capacity && <p className="text-sm text-gray-500 dark:text-gray-400">Capacidade: {grow.capacity}</p>}
+      <button
+        onClick={() => setShowQrModal(true)}
+        className="mt-2 text-xs px-2 py-1 bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 rounded hover:bg-blue-200 dark:hover:bg-blue-800 transition w-max"
+      >
+        Ver QR Code
+      </button>
+
+      <div className="mt-4">
+        {cultivos.length ? (
+          <ul className="space-y-2">
+            {cultivos.map(c => (
+              <li key={c.id} className="p-3 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md">
+                <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2">
+                  <div className="flex flex-col">
+                    <span className="font-semibold text-gray-800 dark:text-gray-100">{c.name}</span>
+                    <span className="text-xs text-gray-500 dark:text-gray-400">{new Date(c.startDate).toLocaleDateString()}</span>
+                  </div>
+                  <div className="flex gap-2">
+                    <Link to={`/cultivo/${c.id}`}>
+                      <Button variant="primary" size="sm">Selecionar Plantio</Button>
+                    </Link>
+                    <Button variant="secondary" size="sm" onClick={() => openMassModal(c)}>Registrar Ação em Massa</Button>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <div className="text-gray-400 dark:text-gray-500">Nenhum plantio neste espaço.</div>
+        )}
+      </div>
+      {grow && (
+        <Modal isOpen={showQrModal} onClose={() => setShowQrModal(false)} title="QR Code do Espaço">
+          <GrowQrCodeDisplay grow={grow} />
+        </Modal>
+      )}
+      {selectedCultivo && (
+        <Modal isOpen={showMassModal} onClose={() => setShowMassModal(false)} title="Registro em Massa" maxWidth="sm">
+          <div className="flex flex-col gap-3 p-2">
+            <input
+              type="number"
+              className="p-2 border rounded"
+              placeholder="Volume de Rega (L)"
+              value={massWateringVolume}
+              onChange={e => setMassWateringVolume(e.target.value)}
+            />
+            <input
+              type="text"
+              className="p-2 border rounded"
+              placeholder="Tipo de Água/Solução"
+              value={massWateringType}
+              onChange={e => setMassWateringType(e.target.value)}
+            />
+            <input
+              type="text"
+              className="p-2 border rounded"
+              placeholder="Tipo de Fertilizante"
+              value={massFertilizationType}
+              onChange={e => setMassFertilizationType(e.target.value)}
+            />
+            <input
+              type="number"
+              className="p-2 border rounded"
+              placeholder="Concentração do Fertilizante"
+              value={massFertilizationConcentration}
+              onChange={e => setMassFertilizationConcentration(e.target.value)}
+            />
+            <input
+              type="text"
+              className="p-2 border rounded"
+              placeholder="Fotoperíodo (ex: 12/12)"
+              value={massPhotoperiod}
+              onChange={e => setMassPhotoperiod(e.target.value)}
+            />
+            <input
+              type="text"
+              className="p-2 border rounded"
+              placeholder="Produto de Pulverização"
+              value={massSprayProduct}
+              onChange={e => setMassSprayProduct(e.target.value)}
+            />
+            <input
+              type="number"
+              className="p-2 border rounded"
+              placeholder="Quantidade Pulverizada"
+              value={massSprayAmount}
+              onChange={e => setMassSprayAmount(e.target.value)}
+            />
+            <textarea
+              className="p-2 border rounded"
+              placeholder="Notas"
+              value={massNotes}
+              onChange={e => setMassNotes(e.target.value)}
+            />
+            <div className="flex gap-3 mt-2">
+              <Button variant="secondary" onClick={() => setShowMassModal(false)}>Cancelar</Button>
+              <Button variant="primary" onClick={handleMassRegister} disabled={!massNotes && !massWateringVolume && !massFertilizationType && !massPhotoperiod && !massSprayProduct}>Salvar</Button>
+            </div>
+          </div>
+        </Modal>
+      )}
+    </div>
+  );
+}

--- a/pages/GrowsPage.tsx
+++ b/pages/GrowsPage.tsx
@@ -80,8 +80,11 @@ export default function GrowsPage() {
           <ul className="space-y-2">
             {grows.map(g => (
               <li key={g.id} className="p-3 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md">
-                <div className="font-semibold text-gray-800 dark:text-gray-100">{g.name}</div>
-                {g.location && <div className="text-sm text-gray-500 dark:text-gray-400">{g.location}</div>}
+                <Link to={`/grow/${g.id}`} className="block">
+                  <div className="font-semibold text-gray-800 dark:text-gray-100">{g.name}</div>
+                  {g.location && <div className="text-sm text-gray-500 dark:text-gray-400">{g.location}</div>}
+                  {g.capacity && <div className="text-sm text-gray-500 dark:text-gray-400">Capacidade: {g.capacity}</div>}
+                </Link>
               </li>
             ))}
           </ul>

--- a/pages/NovoCultivoPage.tsx
+++ b/pages/NovoCultivoPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
+import { useNavigate, Link, useSearchParams } from 'react-router-dom';
 import Button from '../components/Button';
 import ArrowLeftIcon from '../components/icons/ArrowLeftIcon';
 import Toast from '../components/Toast';
@@ -7,12 +7,14 @@ import { SUBSTRATE_OPTIONS } from '../constants';
 import { Grow, PlantStage, PlantHealthStatus, PlantOperationalStatus } from '../types';
 
 export default function NovoCultivoPage() {
+  const [searchParams] = useSearchParams();
+  const initialGrowId = searchParams.get('growId') || '';
   const [cultivoNome, setCultivoNome] = useState('');
   const [startDate, setStartDate] = useState('');
   const [notes, setNotes] = useState('');
   const [substrate, setSubstrate] = useState('');
   const [grows, setGrows] = useState<Grow[]>([]);
-  const [growId, setGrowId] = useState('');
+  const [growId, setGrowId] = useState(initialGrowId);
   const [plants, setPlants] = useState<{ name: string; strain: string }[]>([{ name: '', strain: '' }]);
   const [saving, setSaving] = useState(false);
   const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' | 'info' } | null>(null);

--- a/pages/NovoGrowPage.tsx
+++ b/pages/NovoGrowPage.tsx
@@ -7,6 +7,7 @@ import Toast from '../components/Toast';
 export default function NovoGrowPage() {
   const [name, setName] = useState('');
   const [location, setLocation] = useState('');
+  const [capacity, setCapacity] = useState<number | ''>('');
   const [saving, setSaving] = useState(false);
   const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' | 'info' } | null>(null);
   const navigate = useNavigate();
@@ -24,7 +25,7 @@ export default function NovoGrowPage() {
     setSaving(true);
     try {
       const { addGrow } = await import('../services/growService');
-      const newGrow = await addGrow({ name, location: location || undefined });
+      const newGrow = await addGrow({ name, location: location || undefined, capacity: capacity === '' ? undefined : capacity });
       setToast({ message: 'Grow criado com sucesso! Cadastre seu primeiro cultivo.', type: 'success' });
       setTimeout(() => navigate(`/novo-cultivo?growId=${newGrow.id}`), 1500);
     } catch (err: any) {
@@ -66,6 +67,17 @@ export default function NovoGrowPage() {
           <div>
             <label htmlFor="growLocation" className={labelStyle}>Localização (opcional)</label>
             <input id="growLocation" type="text" className={inputStyle} value={location} onChange={e => setLocation(e.target.value)} />
+          </div>
+          <div>
+            <label htmlFor="growCapacity" className={labelStyle}>Capacidade (opcional)</label>
+            <input
+              id="growCapacity"
+              type="number"
+              className={inputStyle}
+              value={capacity}
+              onChange={e => setCapacity(e.target.value === '' ? '' : parseInt(e.target.value))}
+              min="0"
+            />
           </div>
           <div className="mt-6 flex justify-center">
             <Button type="submit" variant="primary" size="lg" loading={saving} disabled={!name}>Salvar Grow</Button>

--- a/pages/ScannerPage.tsx
+++ b/pages/ScannerPage.tsx
@@ -3,8 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Sidebar from '../components/Sidebar';
 import Header from '../components/Header';
-import QrCodeScanner from '../components/QrCodeScanner';
-import { Plant } from '../types';
+import QrCodeScanner, { ScanResult } from '../components/QrCodeScanner';
 import { Box, Container, Typography } from '@mui/material';
 
 const ScannerPage: React.FC = () => {
@@ -13,8 +12,12 @@ const ScannerPage: React.FC = () => {
   const navigate = useNavigate();
   const { t } = useTranslation();
 
-  const handleScanSuccess = (plant: Plant) => {
-    navigate(`/plant/${plant.id}`);
+  const handleScanSuccess = (result: ScanResult) => {
+    if (result.type === 'plant' && result.plant) {
+      navigate(`/plant/${result.plant.id}`);
+    } else if (result.type === 'grow' && result.grow) {
+      navigate(`/grow/${result.grow.id}`);
+    }
   };
 
   const handleScanError = (message: string) => {
@@ -39,7 +42,7 @@ const ScannerPage: React.FC = () => {
               {scanError}
             </Typography>
           )}
-          <QrCodeScanner onScanSuccess={handleScanSuccess} onScanError={handleScanError} />
+          <QrCodeScanner onScanSuccess={handleScanSuccess} onScanError={handleScanError} scanType="auto" />
         </Container>
       </Box>
     </Box>

--- a/services/growService.ts
+++ b/services/growService.ts
@@ -29,10 +29,16 @@ const fetchWithAuth = async (endpoint: string, options: RequestInit = {}) => {
 
 export const getGrows = async (): Promise<Grow[]> => {
   const data = await fetchWithAuth('getGrows');
-  return Array.isArray(data) ? data : [];
+  return Array.isArray(data)
+    ? data.map((g: any) => ({
+        ...g,
+        qrCodeValue: g.qr_code_value || g.qrCodeValue,
+        createdAt: g.created_at || g.createdAt,
+      }))
+    : [];
 };
 
-export const addGrow = async (grow: { name: string; location?: string }): Promise<Grow> => {
+export const addGrow = async (grow: { name: string; location?: string; capacity?: number }): Promise<Grow> => {
   const data = await fetchWithAuth('addGrow', {
     method: 'POST',
     body: JSON.stringify(grow),

--- a/services/plantService.ts
+++ b/services/plantService.ts
@@ -189,6 +189,17 @@ export const updateDiaryEntry = async (
   return convertKeysToCamelCase(result);
 };
 
+export const addMassDiaryEntry = async (
+  cultivoId: string,
+  entry: Omit<DiaryEntry, 'id' | 'timestamp' | 'plantId'>
+): Promise<number> => {
+  const result = await fetchWithAuth('addMassDiaryEntry', {
+    method: 'POST',
+    body: JSON.stringify({ cultivoId, entry }),
+  });
+  return result.count || 0;
+};
+
 export const deleteDiaryEntry = async (plantId: string, entryId: string): Promise<boolean> => {
   await fetchWithAuth(`deleteDiaryEntry?id=${entryId}&plantId=${plantId}`, {
     method: 'DELETE',

--- a/supabase/diary_entries.sql
+++ b/supabase/diary_entries.sql
@@ -17,6 +17,13 @@ create table if not exists diary_entries (
   humidity numeric,
   symptoms text,
   actions_taken text,
+  watering_volume numeric,
+  watering_type text,
+  fertilization_type text,
+  fertilization_concentration numeric,
+  photoperiod text,
+  spray_product text,
+  spray_amount numeric,
   photos jsonb,
   ai_overall_diagnosis text
 );

--- a/supabase/grows.sql
+++ b/supabase/grows.sql
@@ -4,9 +4,13 @@ create table if not exists grows (
   id uuid primary key default uuid_generate_v4(),
   name text not null,
   location text,
+  capacity integer,
+  qr_code_value text not null unique,
   user_id uuid not null,
   created_at timestamptz not null default now()
 );
 
 alter table cultivos add column if not exists substrate text;
 alter table cultivos add column if not exists grow_id uuid references grows(id);
+alter table grows add column if not exists capacity integer;
+alter table grows add column if not exists qr_code_value text unique;

--- a/types.ts
+++ b/types.ts
@@ -28,6 +28,8 @@ export interface Grow {
   id: string;
   name: string;
   location?: string;
+  capacity?: number;
+  qrCodeValue: string;
   userId: string;
   createdAt: string;
 }
@@ -99,11 +101,18 @@ export interface DiaryEntry {
   ec?: number; 
   ph?: number;
   temperature?: number; 
-  humidity?: number; 
+  humidity?: number;
   symptoms?: string;
-  actionsTaken?: string; 
+  actionsTaken?: string;
+  wateringVolume?: number;
+  wateringType?: string;
+  fertilizationType?: string;
+  fertilizationConcentration?: number;
+  photoperiod?: string;
+  sprayProduct?: string;
+  sprayAmount?: number;
   photos: Photo[];
-  aiOverallDiagnosis?: string; 
+  aiOverallDiagnosis?: string;
 }
 
 export interface SensorReading {


### PR DESCRIPTION
## Summary
- display grow plantings with QR code options
- allow mass action registration from grow detail page

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6848d14fa4cc832a852a1bc61992ef62