### PR TITLE
Implement useToast hook

### DIFF
--- a/components/Toast.tsx
+++ b/components/Toast.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
+import { ToastData } from '../hooks/useToast';
 
 interface ToastProps {
-  message: string;
-  type?: 'success' | 'error' | 'info';
+  toast: ToastData;
   onClose?: () => void;
 }
 
@@ -12,12 +12,14 @@ const typeStyles = {
   info: 'bg-blue-500 text-white',
 };
 
-const Toast: React.FC<ToastProps> = ({ message, type = 'info', onClose }) => (
-  <div
-    className={`fixed bottom-6 left-1/2 z-[9999] -translate-x-1/2 px-6 py-3 rounded-xl shadow-lg flex items-center gap-3 ${typeStyles[type]} animate-toast-in`}
-    role="alert"
-    style={{ minWidth: 200 }}
-  >
+const Toast: React.FC<ToastProps> = ({ toast, onClose }) => {
+  const { message, type = 'info' } = toast;
+  return (
+    <div
+      className={`fixed bottom-6 left-1/2 z-[9999] -translate-x-1/2 px-6 py-3 rounded-xl shadow-lg flex items-center gap-3 ${typeStyles[type]} animate-toast-in`}
+      role="alert"
+      style={{ minWidth: 200 }}
+    >
     {type === 'success' && (
       <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" /></svg>
     )}
@@ -36,6 +38,7 @@ const Toast: React.FC<ToastProps> = ({ message, type = 'info', onClose }) => (
       .animate-toast-in { animation: toast-in 0.3s cubic-bezier(.4,0,.2,1); }
     `}</style>
   </div>
-);
+  );
+};
 
 export default Toast;

--- a/hooks/useToast.ts
+++ b/hooks/useToast.ts
@@ -1,0 +1,31 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export type ToastType = 'success' | 'error' | 'info';
+export interface ToastData {
+  message: string;
+  type?: ToastType;
+}
+
+export default function useToast(delay = 2500): [ToastData | null, (toast: ToastData) => void] {
+  const [toast, setToast] = useState<ToastData | null>(null);
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+
+  const showToast = useCallback((t: ToastData) => {
+    setToast(t);
+  }, []);
+
+  useEffect(() => {
+    if (toast) {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => setToast(null), delay);
+    }
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [toast, delay]);
+
+  return [toast, showToast];
+}

--- a/pages/AllPlantsPage.tsx
+++ b/pages/AllPlantsPage.tsx
@@ -7,6 +7,7 @@ import Header from '../components/Header';
 import Sidebar from '../components/Sidebar';
 import Button from '../components/Button';
 import Toast from '../components/Toast';
+import useToast from '../hooks/useToast';
 import { Cultivo } from '../types';
 import {
   Box,
@@ -31,7 +32,7 @@ const AllPlantsPage: React.FC = () => {
   const [cultivos, setCultivos] = React.useState<Cultivo[]>([]);
   const [selectedCultivo, setSelectedCultivo] = React.useState('');
   const [moving, setMoving] = React.useState(false);
-  const [toast, setToast] = React.useState<{ message: string; type: 'success' | 'error' | 'info' } | null>(null);
+  const [toast, showToast] = useToast();
 
   React.useEffect(() => {
     if (selectionMode) {
@@ -39,12 +40,6 @@ const AllPlantsPage: React.FC = () => {
     }
   }, [selectionMode]);
 
-  React.useEffect(() => {
-    if (toast) {
-      const t = setTimeout(() => setToast(null), 2500);
-      return () => clearTimeout(t);
-    }
-  }, [toast]);
 
   const toggleSelect = (id: string) => {
     setSelectedIds(prev => {
@@ -60,12 +55,12 @@ const AllPlantsPage: React.FC = () => {
     try {
       await Promise.all(Array.from(selectedIds).map(id => updatePlantDetails(id, { cultivoId: selectedCultivo })));
       await refreshPlants();
-      setToast({ message: 'Plantas movidas com sucesso!', type: 'success' });
+      showToast({ message: 'Plantas movidas com sucesso!', type: 'success' });
       setSelectionMode(false);
       setSelectedIds(new Set());
       setSelectedCultivo('');
     } catch (err: any) {
-      setToast({ message: 'Erro ao mover plantas: ' + (err.message || err), type: 'error' });
+      showToast({ message: 'Erro ao mover plantas: ' + (err.message || err), type: 'error' });
     } finally {
       setMoving(false);
     }
@@ -172,7 +167,7 @@ const AllPlantsPage: React.FC = () => {
           <Button variant="ghost" size="sm" onClick={() => { setSelectionMode(false); setSelectedIds(new Set()); }}>Cancelar</Button>
         </Paper>
       )}
-      {toast && <Toast message={toast.message} type={toast.type} />}
+      {toast && <Toast toast={toast} />}
     </>
   );
 };

--- a/pages/CultivoDetailPage.tsx
+++ b/pages/CultivoDetailPage.tsx
@@ -5,6 +5,7 @@ import { Cultivo, Plant, PlantOperationalStatus, PlantStage, Grow } from '../typ
 import Button from '../components/Button';
 import Modal from '../components/Modal';
 import Toast from '../components/Toast';
+import useToast from '../hooks/useToast';
 import Loader from "../components/Loader";
 import PlantCard from '../components/PlantCard';
 import ArrowLeftIcon from '../components/icons/ArrowLeftIcon';
@@ -36,7 +37,7 @@ const CultivoDetailPage: React.FC = () => {
   const [massSprayAmount, setMassSprayAmount] = useState('');
   const [finishing, setFinishing] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' | 'info' } | null>(null);
+  const [toast, showToast] = useToast();
   const [isGeneratingPDF, setIsGeneratingPDF] = useState(false);
 
   // Novo: função para buscar plantas separadamente
@@ -86,21 +87,14 @@ const CultivoDetailPage: React.FC = () => {
     }
   };
 
-  // Toast auto-hide
-  useEffect(() => {
-    if (toast) {
-      const t = setTimeout(() => setToast(null), 2500);
-      return () => clearTimeout(t);
-    }
-  }, [toast]);
 
   const handlePrintQRCodes = async () => {
     if (!cultivo || plants.length === 0) {
-      setToast({ message: 'Nenhuma planta neste cultivo para imprimir QR codes.', type: 'info' });
+      showToast({ message: 'Nenhuma planta neste cultivo para imprimir QR codes.', type: 'info' });
       return;
     }
     setIsGeneratingPDF(true);
-    setToast({ message: 'Gerando PDF com QR codes...', type: 'info' });
+    showToast({ message: 'Gerando PDF com QR codes...', type: 'info' });
     try {
       // Dynamically import the PDF generation utility
       const { generateQRCodesPDF } = await import('@/utils/pdfUtils.ts'); // Ensure path is correct
@@ -108,7 +102,7 @@ const CultivoDetailPage: React.FC = () => {
       // Success toast is optional as download starts
     } catch (error: any) {
       console.error("Error generating QR Code PDF:", error);
-      setToast({ message: `Erro ao gerar PDF: ${error.message || 'Falha desconhecida'}`, type: 'error' });
+      showToast({ message: `Erro ao gerar PDF: ${error.message || 'Falha desconhecida'}`, type: 'error' });
   } finally {
     setIsGeneratingPDF(false);
   }
@@ -120,9 +114,9 @@ const CultivoDetailPage: React.FC = () => {
       await updateCultivo(cultivoId, { growId: selectedGrow });
       setCultivo(prev => prev ? { ...prev, growId: selectedGrow } : prev);
       setShowMoveModal(false);
-      setToast({ message: 'Plantio movido com sucesso!', type: 'success' });
+      showToast({ message: 'Plantio movido com sucesso!', type: 'success' });
     } catch (err) {
-      setToast({ message: 'Erro ao mover plantio.', type: 'error' });
+      showToast({ message: 'Erro ao mover plantio.', type: 'error' });
     }
   };
 
@@ -141,7 +135,7 @@ const CultivoDetailPage: React.FC = () => {
         sprayProduct: massSprayProduct || undefined,
         sprayAmount: massSprayAmount ? parseFloat(massSprayAmount) : undefined,
       });
-      setToast({ message: 'Registro aplicado a todas as plantas', type: 'success' });
+      showToast({ message: 'Registro aplicado a todas as plantas', type: 'success' });
       setShowMassModal(false);
       setMassNotes('');
       setMassWateringVolume('');
@@ -152,7 +146,7 @@ const CultivoDetailPage: React.FC = () => {
       setMassSprayProduct('');
       setMassSprayAmount('');
     } catch (err) {
-      setToast({ message: 'Erro ao registrar em massa', type: 'error' });
+      showToast({ message: 'Erro ao registrar em massa', type: 'error' });
     }
   };
 
@@ -214,9 +208,9 @@ const CultivoDetailPage: React.FC = () => {
       // Por exemplo: updateCultivoInContext(cultivoId, { finalizadoEm: new Date().toISOString() });
       
       setShowFinishModal(false);
-      setToast({ 
-        message: 'Cultivo finalizado! Todas as plantas ativas foram marcadas como colhidas.', 
-        type: 'success' 
+      showToast({
+        message: 'Cultivo finalizado! Todas as plantas ativas foram marcadas como colhidas.',
+        type: 'success'
       });
       
       // 4. Redireciona após um curto atraso para o usuário ver a mensagem
@@ -226,9 +220,9 @@ const CultivoDetailPage: React.FC = () => {
       console.error('[handleFinishCultivo] Erro ao finalizar cultivo:', err);
       const errorMessage = err.message || 'Erro desconhecido ao finalizar cultivo';
       setError('Erro ao finalizar cultivo: ' + errorMessage);
-      setToast({ 
-        message: `Erro ao finalizar cultivo: ${errorMessage}`, 
-        type: 'error' 
+      showToast({
+        message: `Erro ao finalizar cultivo: ${errorMessage}`,
+        type: 'error'
       });
     } finally {
       setFinishing(false);
@@ -260,7 +254,7 @@ const CultivoDetailPage: React.FC = () => {
   return (
     <div className="max-w-lg mx-auto w-full p-2 sm:p-4 min-h-full flex flex-col gap-3 bg-white dark:bg-slate-900">
       {/* Toast global */}
-      {toast && <Toast message={toast.message} type={toast.type} />}
+      {toast && <Toast toast={toast} />}
 
       {/* Breadcrumbs e botão de voltar mobile first */}
       <div className="sticky top-0 z-20 bg-white/80 dark:bg-slate-900/80 flex items-center gap-2 py-2 px-1 sm:px-0 -mx-2 sm:mx-0 backdrop-blur-md">

--- a/pages/GrowDetailPage.tsx
+++ b/pages/GrowDetailPage.tsx
@@ -6,6 +6,7 @@ import PlusIcon from '../components/icons/PlusIcon';
 import Button from '../components/Button';
 import Loader from '../components/Loader';
 import Toast from '../components/Toast';
+import useToast from '../hooks/useToast';
 import Modal from '../components/Modal';
 import GrowQrCodeDisplay from '../components/GrowQrCodeDisplay';
 import { addMassDiaryEntry } from '../services/plantService';
@@ -16,7 +17,7 @@ export default function GrowDetailPage() {
   const [grow, setGrow] = useState<Grow | null>(null);
   const [cultivos, setCultivos] = useState<Cultivo[]>([]);
   const [loading, setLoading] = useState(true);
-  const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' | 'info' } | null>(null);
+  const [toast, showToast] = useToast();
   const [showQrModal, setShowQrModal] = useState(false);
   const [selectedCultivo, setSelectedCultivo] = useState<Cultivo | null>(null);
   const [showMassModal, setShowMassModal] = useState(false);
@@ -38,7 +39,7 @@ export default function GrowDetailPage() {
         setGrow(growList.find(g => g.id === growId) || null);
         setCultivos(cultivosList.filter(c => c.growId === growId));
       } catch (err) {
-        setToast({ message: 'Erro ao carregar dados', type: 'error' });
+        showToast({ message: 'Erro ao carregar dados', type: 'error' });
       } finally {
         setLoading(false);
       }
@@ -73,9 +74,9 @@ export default function GrowDetailPage() {
         sprayAmount: massSprayAmount ? Number(massSprayAmount) : undefined,
         stage: PlantStage.VEGETATIVE,
       });
-      setToast({ message: 'Ação registrada em massa com sucesso', type: 'success' });
+      showToast({ message: 'Ação registrada em massa com sucesso', type: 'success' });
     } catch (e: any) {
-      setToast({ message: e.message || 'Erro ao registrar ação em massa', type: 'error' });
+      showToast({ message: e.message || 'Erro ao registrar ação em massa', type: 'error' });
     } finally {
       setShowMassModal(false);
     }
@@ -99,7 +100,7 @@ export default function GrowDetailPage() {
 
   return (
     <div className="max-w-lg mx-auto w-full min-h-full flex flex-col gap-3 bg-white dark:bg-slate-900 p-2 sm:p-4">
-      {toast && <Toast message={toast.message} type={toast.type} />}
+      {toast && <Toast toast={toast} />}
       <div className="sticky top-0 z-20 bg-white/80 dark:bg-slate-900/80 flex items-center gap-2 py-2 px-1 sm:px-0 -mx-2 sm:mx-0 backdrop-blur-md mb-2">
         <button
           onClick={() => navigate(-1)}

--- a/pages/GrowsPage.tsx
+++ b/pages/GrowsPage.tsx
@@ -5,12 +5,13 @@ import Button from '../components/Button';
 import ArrowLeftIcon from '../components/icons/ArrowLeftIcon';
 import PlusIcon from '../components/icons/PlusIcon';
 import Toast from '../components/Toast';
+import useToast from '../hooks/useToast';
 import Loader from "../components/Loader";
 
 export default function GrowsPage() {
   const [grows, setGrows] = useState<Grow[]>([]);
   const [loading, setLoading] = useState(true);
-  const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' | 'info' } | null>(null);
+  const [toast, showToast] = useToast();
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -34,12 +35,6 @@ export default function GrowsPage() {
     setGrows(data);
   };
 
-  useEffect(() => {
-    if (toast) {
-      const t = setTimeout(() => setToast(null), 2500);
-      return () => clearTimeout(t);
-    }
-  }, [toast]);
 
   if (loading) {
     return (
@@ -51,7 +46,7 @@ export default function GrowsPage() {
 
   return (
     <div className="max-w-lg mx-auto w-full min-h-full flex flex-col gap-3 bg-white dark:bg-slate-900 p-2 sm:p-4">
-      {toast && <Toast message={toast.message} type={toast.type} />}
+      {toast && <Toast toast={toast} />}
       <div className="sticky top-0 z-20 bg-white/80 dark:bg-slate-900/80 flex items-center gap-2 py-2 px-1 sm:px-0 -mx-2 sm:mx-0 backdrop-blur-md mb-2">
         <button
           onClick={() => navigate(-1)}

--- a/pages/NovaPlantaPage.tsx
+++ b/pages/NovaPlantaPage.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import ArrowLeftIcon from '../components/icons/ArrowLeftIcon';
 import Toast from '../components/Toast';
+import useToast from '../hooks/useToast';
 import PlantaForm from '../components/PlantaForm';
 import { usePlantContext } from '../contexts/PlantContext';
 import { PlantStage, PlantHealthStatus, PlantOperationalStatus } from '../types';
@@ -10,30 +11,23 @@ export default function NovaPlantaPage() {
   const [searchParams] = useSearchParams();
   const cultivoId = searchParams.get('cultivoId');
   const [saving, setSaving] = useState(false);
-  const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' | 'info' } | null>(null);
+  const [toast, showToast] = useToast();
   const navigate = useNavigate();
   const { addPlant, error: plantContextError } = usePlantContext();
 
   // Verifica se há um cultivoId na URL
   useEffect(() => {
     if (!cultivoId) {
-      setToast({ message: 'ID do cultivo não fornecido', type: 'error' });
+      showToast({ message: 'ID do cultivo não fornecido', type: 'error' });
       setTimeout(() => navigate('/cultivos'), 2000);
     }
   }, [cultivoId, navigate]);
 
-  // Auto-hide para o toast
-  useEffect(() => {
-    if (toast) {
-      const timer = setTimeout(() => setToast(null), 3000);
-      return () => clearTimeout(timer);
-    }
-  }, [toast]);
 
   // Handler para submissão do formulário usando o método principal
   const handlePlantaSubmit = async (values: { name: string; strain: string; birthDate: string; substrate: string }) => {
     if (!cultivoId) {
-      setToast({ message: 'ID do cultivo não encontrado', type: 'error' });
+      showToast({ message: 'ID do cultivo não encontrado', type: 'error' });
       return;
     }
     setSaving(true);
@@ -49,13 +43,13 @@ export default function NovaPlantaPage() {
       };
       const addedPlant = await addPlant(newPlant);
       if (addedPlant) {
-        setToast({ message: 'Planta adicionada com sucesso!', type: 'success' });
+        showToast({ message: 'Planta adicionada com sucesso!', type: 'success' });
         setTimeout(() => navigate(`/cultivo/${cultivoId}`), 1400);
       } else {
-        setToast({ message: `Erro ao adicionar planta: ${plantContextError || 'Nenhum detalhe retornado.'}`, type: 'error' });
+        showToast({ message: `Erro ao adicionar planta: ${plantContextError || 'Nenhum detalhe retornado.'}`, type: 'error' });
       }
     } catch (error: any) {
-      setToast({ message: 'Erro ao adicionar planta: ' + (error.message || error), type: 'error' });
+      showToast({ message: 'Erro ao adicionar planta: ' + (error.message || error), type: 'error' });
     } finally {
       setSaving(false);
     }
@@ -64,7 +58,7 @@ export default function NovaPlantaPage() {
 
   return (
     <div className="max-w-lg mx-auto w-full min-h-full flex flex-col gap-3 bg-white dark:bg-slate-900 p-2 sm:p-4">
-      {toast && <Toast message={toast.message} type={toast.type} />}
+      {toast && <Toast toast={toast} />}
       <div className="sticky top-0 z-20 bg-white/80 dark:bg-slate-900/80 flex items-center gap-2 py-2 px-1 sm:px-0 -mx-2 sm:mx-0 backdrop-blur-md mb-2">
         <button
           onClick={() => navigate(-1)}

--- a/pages/NovoCultivoPage.tsx
+++ b/pages/NovoCultivoPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, Link, useSearchParams } from 'react-router-dom';
 import Button from '../components/Button';
 import ArrowLeftIcon from '../components/icons/ArrowLeftIcon';
 import Toast from '../components/Toast';
+import useToast from '../hooks/useToast';
 import { SUBSTRATE_OPTIONS } from '../constants';
 import { Grow, PlantStage, PlantHealthStatus, PlantOperationalStatus } from '../types';
 
@@ -17,7 +18,7 @@ export default function NovoCultivoPage() {
   const [growId, setGrowId] = useState(initialGrowId);
   const [plants, setPlants] = useState<{ name: string; strain: string }[]>([{ name: '', strain: '' }]);
   const [saving, setSaving] = useState(false);
-  const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' | 'info' } | null>(null);
+  const [toast, showToast] = useToast();
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -68,11 +69,11 @@ export default function NovoCultivoPage() {
       };
       await addCultivo(cultivoData);
       setSaving(false);
-      setToast({ message: 'Cultivo criado com sucesso!', type: 'success' });
+      showToast({ message: 'Cultivo criado com sucesso!', type: 'success' });
       setTimeout(() => navigate('/cultivos'), 1800);
     } catch (err: any) {
       setSaving(false);
-      setToast({ message: 'Erro ao salvar cultivo: ' + (err.message || err), type: 'error' });
+      showToast({ message: 'Erro ao salvar cultivo: ' + (err.message || err), type: 'error' });
     }
   }
 
@@ -82,7 +83,7 @@ export default function NovoCultivoPage() {
   return (
     <div className="mx-auto w-full max-w-3xl lg:max-w-5xl min-h-full flex flex-col gap-3 bg-white dark:bg-slate-900 p-2 sm:p-4">
       {/* Toast global */}
-      {toast && <Toast message={toast.message} type={toast.type} />}
+      {toast && <Toast toast={toast} />}
 
       {/* Breadcrumbs e botão de voltar */}
       <div className="sticky top-0 z-20 bg-white/80 dark:bg-slate-900/80 flex items-center gap-2 py-2 px-1 sm:px-0 -mx-2 sm:mx-0 backdrop-blur-md mb-2">

--- a/pages/NovoGrowPage.tsx
+++ b/pages/NovoGrowPage.tsx
@@ -3,21 +3,16 @@ import { useNavigate, Link } from 'react-router-dom';
 import Button from '../components/Button';
 import ArrowLeftIcon from '../components/icons/ArrowLeftIcon';
 import Toast from '../components/Toast';
+import useToast from '../hooks/useToast';
 
 export default function NovoGrowPage() {
   const [name, setName] = useState('');
   const [location, setLocation] = useState('');
   const [capacity, setCapacity] = useState<number | ''>('');
   const [saving, setSaving] = useState(false);
-  const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' | 'info' } | null>(null);
+  const [toast, showToast] = useToast();
   const navigate = useNavigate();
 
-  useEffect(() => {
-    if (toast) {
-      const t = setTimeout(() => setToast(null), 2500);
-      return () => clearTimeout(t);
-    }
-  }, [toast]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -26,10 +21,10 @@ export default function NovoGrowPage() {
     try {
       const { addGrow } = await import('../services/growService');
       const newGrow = await addGrow({ name, location: location || undefined, capacity: capacity === '' ? undefined : capacity });
-      setToast({ message: 'Grow criado com sucesso! Cadastre seu primeiro cultivo.', type: 'success' });
+      showToast({ message: 'Grow criado com sucesso! Cadastre seu primeiro cultivo.', type: 'success' });
       setTimeout(() => navigate(`/novo-cultivo?growId=${newGrow.id}`), 1500);
     } catch (err: any) {
-      setToast({ message: 'Erro ao criar grow: ' + (err.message || err), type: 'error' });
+      showToast({ message: 'Erro ao criar grow: ' + (err.message || err), type: 'error' });
     } finally {
       setSaving(false);
     }
@@ -40,7 +35,7 @@ export default function NovoGrowPage() {
 
   return (
     <div className="max-w-lg mx-auto w-full min-h-full flex flex-col gap-3 bg-white dark:bg-slate-900 p-2 sm:p-4">
-      {toast && <Toast message={toast.message} type={toast.type} />}
+      {toast && <Toast toast={toast} />}
       <div className="sticky top-0 z-20 bg-white/80 dark:bg-slate-900/80 flex items-center gap-2 py-2 px-1 sm:px-0 -mx-2 sm:mx-0 backdrop-blur-md mb-2">
         <button
           onClick={() => navigate(-1)}

--- a/pages/PlantDetailPage.tsx
+++ b/pages/PlantDetailPage.tsx
@@ -12,6 +12,7 @@ import Sidebar from '../components/Sidebar';
 import Header from '../components/Header';
 import LeafIcon from '../components/icons/LeafIcon';
 import Toast from '../components/Toast';
+import useToast from '../hooks/useToast';
 
 const PlantDetailPage: React.FC = () => {
   const { plantId } = useParams<{ plantId: string }>();
@@ -40,7 +41,7 @@ const PlantDetailPage: React.FC = () => {
   const [cultivos, setCultivos] = useState<{ id: string; name: string }[]>([]);
   const [selectedCultivo, setSelectedCultivo] = useState<string | undefined>(undefined);
   const [movingCultivo, setMovingCultivo] = useState(false);
-  const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' | 'info' } | null>(null);
+  const [toast, showToast] = useToast();
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [showDiaryEntryModal, setShowDiaryEntryModal] = useState(false);
   const [isSavingDiaryEntry, setIsSavingDiaryEntry] = useState(false);
@@ -152,7 +153,7 @@ const PlantDetailPage: React.FC = () => {
       try {
         await updatePlantDetails(plantId, payload);
       } catch (err: any) {
-        setToast({ message: 'Erro ao atualizar checklist: ' + (err.message || err), type: 'error' });
+        showToast({ message: 'Erro ao atualizar checklist: ' + (err.message || err), type: 'error' });
       }
     }
   };
@@ -219,23 +220,17 @@ const PlantDetailPage: React.FC = () => {
         const entries = await getDiaryEntries(plantId);
         setDiaryEntries(entries.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()));
         setShowDiaryEntryModal(false);
-        setToast({ message: 'Entrada do diário salva!', type: 'success' });
+        showToast({ message: 'Entrada do diário salva!', type: 'success' });
       } else {
-        setToast({ message: 'Erro ao salvar entrada no diário.', type: 'error' });
+        showToast({ message: 'Erro ao salvar entrada no diário.', type: 'error' });
       }
     } catch (err: any) {
-      setToast({ message: `Erro: ${err.message || 'Falha ao salvar entrada.'}`, type: 'error' });
+      showToast({ message: `Erro: ${err.message || 'Falha ao salvar entrada.'}`, type: 'error' });
     } finally {
       setIsSavingDiaryEntry(false);
     }
   };
 
-  useEffect(() => {
-    if (toast) {
-      const timer = setTimeout(() => setToast(null), 3000);
-      return () => clearTimeout(timer);
-    }
-  }, [toast]);
 
 
   if (!plant) {
@@ -291,7 +286,7 @@ const PlantDetailPage: React.FC = () => {
           showBack
           onBack={() => navigate(-1)}
         />
-          {toast && <Toast message={toast.message} type={toast.type} />}
+          {toast && <Toast toast={toast} />}
           <main className="flex-1 max-w-7xl mx-auto w-full px-2 sm:px-6 lg:px-8 pt-6">
             {plant && (
               <div style={{ display: 'none' }}>
@@ -378,10 +373,10 @@ const PlantDetailPage: React.FC = () => {
                           try {
                             await updatePlantDetails(plantId, { cultivoId: selectedCultivo });
                             await loadPlantData();
-                            setToast({ message: 'Planta movida!', type: 'success' });
+                            showToast({ message: 'Planta movida!', type: 'success' });
                             setSelectedCultivo(undefined);
                           } catch (err: any) {
-                            setToast({ message: 'Erro ao mover planta: ' + (err.message || err), type: 'error' });
+                            showToast({ message: 'Erro ao mover planta: ' + (err.message || err), type: 'error' });
                           }
                           setMovingCultivo(false);
                         }}


### PR DESCRIPTION
## Summary
- add reusable `useToast` hook with auto hide
- refactor `Toast` to accept `toast` prop
- update pages to use new hook

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'jspdf' or its corresponding type declarations)*
- `npm run build` *(fails: vite: not found)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68497e33cf84832aa3e594ea339602df