### PR TITLE
Add i18n hooks to pages

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -98,5 +98,86 @@
     "no_cultivos": "No cultivos registered yet.",
     "create_first": "Create your first cultivo",
     "new_cultivo": "New Cultivo"
+  },
+  "allPlantsPage": {
+    "title": "All Plants",
+    "move_plants": "Move Plants",
+    "selection": "{{count}} selected. Tap plants to select.",
+    "no_plants": "No plants registered yet.",
+    "add_new_plant": "Add New Plant",
+    "choose_cultivo": "Choose cultivo",
+    "move": "Move",
+    "cancel": "Cancel",
+    "move_success": "Plants moved successfully!",
+    "move_error": "Error moving plants:"
+  },
+  "growsPage": {
+    "title": "My Grows",
+    "loading": "Loading grows...",
+    "no_grows": "No grows registered yet.",
+    "create_first": "Create your first grow",
+    "new_grow": "New Grow"
+  },
+  "growDetailPage": {
+    "not_found": "Grow not found",
+    "view_qr": "View QR Code",
+    "select_cultivo": "Select Plantio",
+    "mass_action": "Mass Action",
+    "no_cultivos": "No cultivo in this grow.",
+    "mass_title": "Mass Registration"
+  },
+  "cultivoDetailPage": {
+    "loading": "Loading cultivo...",
+    "try_again": "Try again",
+    "not_found": "Cultivo not found.",
+    "back_to_list": "Back to cultivos"
+  },
+  "novoGrowPage": {
+    "title": "New Grow",
+    "name": "Grow Name",
+    "location": "Location (optional)",
+    "capacity": "Capacity (optional)",
+    "save": "Save Grow"
+  },
+  "cultivoEtiquetasPage": {
+    "title": "Cultivo QR Labels",
+    "print": "Print"
+  },
+  "novoCultivoPage": {
+    "title": "New Cultivo",
+    "info_section": "Cultivo Information",
+    "plants_section": "Plants",
+    "cultivo_name": "Cultivo Name",
+    "start_date": "Start Date",
+    "grow": "Grow / Greenhouse",
+    "substrate": "Substrate",
+    "notes": "Notes (optional)",
+    "add_plant": "Add Plant",
+    "remove": "Remove",
+    "save": "Save Cultivo"
+  },
+  "novaPlantaPage": {
+    "title": "New Plant",
+    "add_new_plant": "Add New Plant",
+    "error_no_cultivo": "Cultivo ID not provided"
+  },
+  "plantDetailPage": {
+    "title": "Plant Details",
+    "daily_checklist": "Daily Checklist",
+    "diary": "Plant Diary",
+    "new_entry": "New Entry",
+    "download_qr": "Download QR Code",
+    "remove_disease": "Remove Plant due to Disease",
+    "confirm_remove": "Are you sure you want to remove this plant due to disease?",
+    "reason_optional": "Reason or note (optional)"
+  },
+  "plantStatisticsPage": {
+    "title": "Statistics of {{name}}",
+    "back": "Back to Details",
+    "more_details": "More Plant Details"
+  },
+  "gardenStatisticsPage": {
+    "title": "Garden Statistics",
+    "back_dashboard": "Back to Dashboard"
   }
 }

--- a/locales/pt/translation.json
+++ b/locales/pt/translation.json
@@ -98,5 +98,86 @@
     "no_cultivos": "Nenhum cultivo cadastrado ainda.",
     "create_first": "Crie seu primeiro cultivo",
     "new_cultivo": "Novo Cultivo"
+  },
+  "allPlantsPage": {
+    "title": "Todas as Plantas",
+    "move_plants": "Mover Plantas",
+    "selection": "{{count}} selecionada(s). Toque nas plantas para selecionar.",
+    "no_plants": "Nenhuma planta cadastrada ainda.",
+    "add_new_plant": "Adicionar Nova Planta",
+    "choose_cultivo": "Escolha o cultivo",
+    "move": "Mover",
+    "cancel": "Cancelar",
+    "move_success": "Plantas movidas com sucesso!",
+    "move_error": "Erro ao mover plantas:"
+  },
+  "growsPage": {
+    "title": "Meus Grows",
+    "loading": "Carregando estufas...",
+    "no_grows": "Nenhum grow cadastrado ainda.",
+    "create_first": "Crie sua primeira estufa",
+    "new_grow": "Novo Grow"
+  },
+  "growDetailPage": {
+    "not_found": "Espaço não encontrado",
+    "view_qr": "Ver QR Code",
+    "select_cultivo": "Selecionar Plantio",
+    "mass_action": "Registrar Ação em Massa",
+    "no_cultivos": "Nenhum plantio neste espaço.",
+    "mass_title": "Registro em Massa"
+  },
+  "cultivoDetailPage": {
+    "loading": "Carregando cultivo...",
+    "try_again": "Tentar novamente",
+    "not_found": "Cultivo não encontrado.",
+    "back_to_list": "Voltar para cultivos"
+  },
+  "novoGrowPage": {
+    "title": "Novo Grow",
+    "name": "Nome do Grow",
+    "location": "Localização (opcional)",
+    "capacity": "Capacidade (opcional)",
+    "save": "Salvar Grow"
+  },
+  "cultivoEtiquetasPage": {
+    "title": "Etiquetas QR do Cultivo",
+    "print": "Imprimir"
+  },
+  "novoCultivoPage": {
+    "title": "Novo Cultivo",
+    "info_section": "Informações do Cultivo",
+    "plants_section": "Plantas",
+    "cultivo_name": "Nome do Cultivo",
+    "start_date": "Data de Início",
+    "grow": "Grow / Estufa",
+    "substrate": "Substrato",
+    "notes": "Notas (opcional)",
+    "add_plant": "+ Adicionar Planta",
+    "remove": "Remover",
+    "save": "Salvar Cultivo"
+  },
+  "novaPlantaPage": {
+    "title": "Nova Planta",
+    "add_new_plant": "Adicionar Nova Planta",
+    "error_no_cultivo": "ID do cultivo não fornecido"
+  },
+  "plantDetailPage": {
+    "title": "Detalhes da Planta",
+    "daily_checklist": "Checklist Diário",
+    "diary": "Diário da Planta",
+    "new_entry": "Nova Entrada",
+    "download_qr": "Baixar QR Code",
+    "remove_disease": "Remover Planta por Doença",
+    "confirm_remove": "Tem certeza que deseja remover esta planta por doença?",
+    "reason_optional": "Motivo ou observação (opcional)"
+  },
+  "plantStatisticsPage": {
+    "title": "Estatísticas de {{name}}",
+    "back": "Voltar aos Detalhes",
+    "more_details": "Mais Detalhes da Planta"
+  },
+  "gardenStatisticsPage": {
+    "title": "Estatísticas do Jardim",
+    "back_dashboard": "Voltar ao Dashboard"
   }
 }

--- a/pages/AllPlantsPage.tsx
+++ b/pages/AllPlantsPage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { usePlantContext } from '../contexts/PlantContext';
+import { useTranslation } from 'react-i18next';
 import PlantCard from '../components/PlantCard';
 import Loader from '../components/Loader';
 import Header from '../components/Header';
@@ -25,6 +26,7 @@ import {
 const AllPlantsPage: React.FC = () => {
   const { plants, isLoading, error, updatePlantDetails, refreshPlants } = usePlantContext();
   const navigate = useNavigate();
+  const { t } = useTranslation();
   const [isSidebarOpen, setIsSidebarOpen] = React.useState(false);
   const [selectionMode, setSelectionMode] = React.useState(false);
   const [selectedIds, setSelectedIds] = React.useState<Set<string>>(new Set());
@@ -60,12 +62,12 @@ const AllPlantsPage: React.FC = () => {
     try {
       await Promise.all(Array.from(selectedIds).map(id => updatePlantDetails(id, { cultivoId: selectedCultivo })));
       await refreshPlants();
-      setToast({ message: 'Plantas movidas com sucesso!', type: 'success' });
+      setToast({ message: t('allPlantsPage.move_success'), type: 'success' });
       setSelectionMode(false);
       setSelectedIds(new Set());
       setSelectedCultivo('');
     } catch (err: any) {
-      setToast({ message: 'Erro ao mover plantas: ' + (err.message || err), type: 'error' });
+      setToast({ message: t('allPlantsPage.move_error') + (err.message || err), type: 'error' });
     } finally {
       setMoving(false);
     }
@@ -77,7 +79,7 @@ const AllPlantsPage: React.FC = () => {
         <Sidebar isOpen={isSidebarOpen} onClose={() => setIsSidebarOpen(false)} />
         <Box component="main" sx={{ flexGrow: 1 }}>
           <Header
-            title="Todas as Plantas"
+            title={t('allPlantsPage.title')}
             onOpenSidebar={() => setIsSidebarOpen(true)}
             onOpenAddModal={() => navigate('/nova-planta')}
             onOpenScannerModal={() => navigate('/scanner')}
@@ -87,24 +89,24 @@ const AllPlantsPage: React.FC = () => {
           <Container sx={{ py: 4 }}>
             <Box display="flex" alignItems="center" mb={2}>
               <Link to="/" style={{ textDecoration: 'none' }}>
-                <Typography variant="body2" color="text.secondary">Dashboard</Typography>
+                <Typography variant="body2" color="text.secondary">{t('sidebar.dashboard')}</Typography>
               </Link>
               <Typography variant="body2" color="text.secondary" sx={{ mx: 1 }}>
                 &gt;
               </Typography>
               <Typography variant="body2" fontWeight="bold">
-                Todas as Plantas
+                {t('allPlantsPage.title')}
               </Typography>
               <Box sx={{ flexGrow: 1 }} />
               {!selectionMode && plants.length > 0 && (
                 <Button variant="secondary" onClick={() => setSelectionMode(true)}>
-                  Mover Plantas
+                  {t('allPlantsPage.move_plants')}
                 </Button>
               )}
             </Box>
             {selectionMode && (
               <Typography variant="body2" color="text.secondary" mb={2}>
-                {selectedIds.size} selecionada(s). Toque nas plantas para selecionar.
+                {t('allPlantsPage.selection', { count: selectedIds.size })}
               </Typography>
             )}
             {isLoading ? (
@@ -117,13 +119,13 @@ const AllPlantsPage: React.FC = () => {
               </Paper>
             ) : plants.length === 0 ? (
               <Paper sx={{ p: 3, textAlign: 'center' }}>
-                <Typography>Nenhuma planta cadastrada ainda.</Typography>
+                <Typography>{t('allPlantsPage.no_plants')}</Typography>
                 <Button
                   variant="primary"
                   sx={{ mt: 2 }}
                   onClick={() => navigate('/nova-planta')}
                 >
-                  Adicionar Nova Planta
+                  {t('allPlantsPage.add_new_plant')}
                 </Button>
               </Paper>
             ) : (
@@ -147,14 +149,14 @@ const AllPlantsPage: React.FC = () => {
       {selectionMode && (
         <Paper sx={{ position: 'fixed', bottom: 0, left: 0, right: 0, p: 2, display: 'flex', gap: 2 }} elevation={3}>
           <FormControl fullWidth size="small">
-            <InputLabel id="cultivo-select-label">Escolha o cultivo</InputLabel>
+            <InputLabel id="cultivo-select-label">{t('allPlantsPage.choose_cultivo')}</InputLabel>
             <Select
               labelId="cultivo-select-label"
               value={selectedCultivo}
-              label="Escolha o cultivo"
+              label={t('allPlantsPage.choose_cultivo')}
               onChange={e => setSelectedCultivo(e.target.value)}
             >
-              <MenuItem value="">Escolha o cultivo</MenuItem>
+              <MenuItem value="">{t('allPlantsPage.choose_cultivo')}</MenuItem>
               {cultivos.map(c => (
                 <MenuItem key={c.id} value={c.id}>{c.name}</MenuItem>
               ))}
@@ -167,9 +169,9 @@ const AllPlantsPage: React.FC = () => {
             disabled={moving || selectedIds.size === 0 || !selectedCultivo}
             loading={moving}
           >
-            Mover
+            {t('allPlantsPage.move')}
           </Button>
-          <Button variant="ghost" size="sm" onClick={() => { setSelectionMode(false); setSelectedIds(new Set()); }}>Cancelar</Button>
+          <Button variant="ghost" size="sm" onClick={() => { setSelectionMode(false); setSelectedIds(new Set()); }}>{t('allPlantsPage.cancel')}</Button>
         </Paper>
       )}
       {toast && <Toast message={toast.message} type={toast.type} />}

--- a/pages/CultivoDetailPage.tsx
+++ b/pages/CultivoDetailPage.tsx
@@ -11,6 +11,7 @@ import ArrowLeftIcon from '../components/icons/ArrowLeftIcon';
 import CheckCircleIcon from '../components/icons/CheckCircleIcon';
 import LeafIcon from '../components/icons/LeafIcon';
 import PlusIcon from '../components/icons/PlusIcon';
+import { useTranslation } from 'react-i18next';
 import { getPlantsByCultivo, updateCultivo } from '../services/cultivoService';
 import { getGrows } from '../services/growService';
 import { updatePlant } from '../services/plantService';
@@ -18,6 +19,7 @@ import { updatePlant } from '../services/plantService';
 const CultivoDetailPage: React.FC = () => {
   const { cultivoId } = useParams<{ cultivoId: string }>();
   const navigate = useNavigate();
+  const { t } = useTranslation();
   const [cultivo, setCultivo] = useState<Cultivo | null>(null);
   const [plants, setPlants] = useState<Plant[]>([]);
   const [loading, setLoading] = useState(true);
@@ -237,21 +239,21 @@ const CultivoDetailPage: React.FC = () => {
 
   if (loading) return (
     <div className="flex flex-col items-center justify-center min-h-full p-6">
-      <Loader message="Carregando cultivo..." size="md" />
+      <Loader message={t('cultivoDetailPage.loading')} size="md" />
     </div>
   );
   if (error) return (
     <div className="flex flex-col items-center justify-center min-h-full p-6">
       <LeafIcon className="w-12 h-12 text-red-400 mb-3" />
       <span className="text-red-600 dark:text-red-400 font-semibold text-lg mb-2">{error}</span>
-      <Button variant="secondary" onClick={() => window.location.reload()}>Tentar novamente</Button>
+      <Button variant="secondary" onClick={() => window.location.reload()}>{t('cultivoDetailPage.try_again')}</Button>
     </div>
   );
   if (!cultivo) return (
     <div className="flex flex-col items-center justify-center min-h-full p-6">
       <LeafIcon className="w-12 h-12 text-gray-400 mb-3" />
-      <span className="text-gray-500 dark:text-gray-400 font-semibold text-lg">Cultivo não encontrado.</span>
-      <Button variant="secondary" onClick={() => navigate('/cultivos')}>Voltar para cultivos</Button>
+      <span className="text-gray-500 dark:text-gray-400 font-semibold text-lg">{t('cultivoDetailPage.not_found')}</span>
+      <Button variant="secondary" onClick={() => navigate('/cultivos')}>{t('cultivoDetailPage.back_to_list')}</Button>
     </div>
   );
 

--- a/pages/CultivoEtiquetasPage.tsx
+++ b/pages/CultivoEtiquetasPage.tsx
@@ -3,10 +3,12 @@ import { useParams } from 'react-router-dom';
 import QRCode from 'qrcode.react';
 import Button from '../components/Button';
 import { Plant } from '../types';
+import { useTranslation } from 'react-i18next';
 
 export default function CultivoEtiquetasPage() {
   const { cultivoId } = useParams<{ cultivoId: string }>();
   const [plants, setPlants] = useState<Plant[]>([]);
+  const { t } = useTranslation();
 
   useEffect(() => {
     if (cultivoId) {
@@ -22,8 +24,8 @@ export default function CultivoEtiquetasPage() {
   return (
     <div className="p-4">
       <div className="flex justify-between items-center mb-6">
-        <h1 className="text-2xl font-bold">Etiquetas QR do Cultivo</h1>
-        <Button onClick={() => window.print()}>Imprimir</Button>
+        <h1 className="text-2xl font-bold">{t('cultivoEtiquetasPage.title')}</h1>
+        <Button onClick={() => window.print()}>{t('cultivoEtiquetasPage.print')}</Button>
       </div>
       <div className="a4-print-grid">
         {plants.map((plant) => (

--- a/pages/GardenStatisticsPage.tsx
+++ b/pages/GardenStatisticsPage.tsx
@@ -1,17 +1,19 @@
 import React from 'react';
 import DashboardStats from '../components/DashboardStats';
 import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 
 const GardenStatisticsPage: React.FC = () => {
+  const { t } = useTranslation();
   return (
     <div className="p-4 bg-slate-900 min-h-full text-slate-100 space-y-8 w-full">
       <div className="flex justify-between items-center mb-6">
-        <h1 className="text-3xl font-bold text-green-400">Estatísticas do Jardim</h1>
-        <Link 
+        <h1 className="text-3xl font-bold text-green-400">{t('gardenStatisticsPage.title')}</h1>
+        <Link
           to="/"
           className="bg-slate-700 hover:bg-slate-600 text-white font-semibold px-4 py-2 rounded-lg shadow transition-colors"
         >
-          Voltar ao Dashboard
+          {t('gardenStatisticsPage.back_dashboard')}
         </Link>
       </div>
       <div className="bg-white dark:bg-slate-800 p-5 sm:p-8 rounded-xl shadow-xl transition-colors duration-300">

--- a/pages/GrowDetailPage.tsx
+++ b/pages/GrowDetailPage.tsx
@@ -9,10 +9,12 @@ import Toast from '../components/Toast';
 import Modal from '../components/Modal';
 import GrowQrCodeDisplay from '../components/GrowQrCodeDisplay';
 import { addMassDiaryEntry } from '../services/plantService';
+import { useTranslation } from 'react-i18next';
 
 export default function GrowDetailPage() {
   const { growId } = useParams<{ growId: string }>();
   const navigate = useNavigate();
+  const { t } = useTranslation();
   const [grow, setGrow] = useState<Grow | null>(null);
   const [cultivos, setCultivos] = useState<Cultivo[]>([]);
   const [loading, setLoading] = useState(true);
@@ -92,7 +94,7 @@ export default function GrowDetailPage() {
   if (!grow) {
     return (
       <div className="flex flex-col items-center justify-center min-h-full p-6">
-        Espaço não encontrado
+        {t('growDetailPage.not_found')}
       </div>
     );
   }
@@ -130,7 +132,7 @@ export default function GrowDetailPage() {
         onClick={() => setShowQrModal(true)}
         className="mt-2 text-xs px-2 py-1 bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 rounded hover:bg-blue-200 dark:hover:bg-blue-800 transition w-max"
       >
-        Ver QR Code
+        {t('growDetailPage.view_qr')}
       </button>
 
       <div className="mt-4">
@@ -145,16 +147,16 @@ export default function GrowDetailPage() {
                   </div>
                   <div className="flex gap-2">
                     <Link to={`/cultivo/${c.id}`}>
-                      <Button variant="primary" size="sm">Selecionar Plantio</Button>
+                      <Button variant="primary" size="sm">{t('growDetailPage.select_cultivo')}</Button>
                     </Link>
-                    <Button variant="secondary" size="sm" onClick={() => openMassModal(c)}>Registrar Ação em Massa</Button>
+                    <Button variant="secondary" size="sm" onClick={() => openMassModal(c)}>{t('growDetailPage.mass_action')}</Button>
                   </div>
                 </div>
               </li>
             ))}
           </ul>
         ) : (
-          <div className="text-gray-400 dark:text-gray-500">Nenhum plantio neste espaço.</div>
+          <div className="text-gray-400 dark:text-gray-500">{t('growDetailPage.no_cultivos')}</div>
         )}
       </div>
       {grow && (

--- a/pages/GrowsPage.tsx
+++ b/pages/GrowsPage.tsx
@@ -6,12 +6,14 @@ import ArrowLeftIcon from '../components/icons/ArrowLeftIcon';
 import PlusIcon from '../components/icons/PlusIcon';
 import Toast from '../components/Toast';
 import Loader from "../components/Loader";
+import { useTranslation } from 'react-i18next';
 
 export default function GrowsPage() {
   const [grows, setGrows] = useState<Grow[]>([]);
   const [loading, setLoading] = useState(true);
   const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' | 'info' } | null>(null);
   const navigate = useNavigate();
+  const { t } = useTranslation();
 
   useEffect(() => {
     async function fetchData() {
@@ -44,7 +46,7 @@ export default function GrowsPage() {
   if (loading) {
     return (
       <div className="flex flex-col items-center justify-center min-h-full p-6">
-        <Loader message="Carregando estufas..." size="md" />
+        <Loader message={t('growsPage.loading')} size="md" />
       </div>
     );
   }
@@ -67,13 +69,13 @@ export default function GrowsPage() {
         </nav>
         <div className="flex-1" />
         <Link to="/novo-grow">
-          <Button variant="primary" size="icon" className="shadow" title="Novo Grow">
+          <Button variant="primary" size="icon" className="shadow" title={t('growsPage.new_grow')}>
             <PlusIcon className="w-5 h-5" />
           </Button>
         </Link>
       </div>
 
-      <h1 className="text-2xl font-extrabold text-green-700 dark:text-green-300 mt-4 mb-2">Meus Grows</h1>
+      <h1 className="text-2xl font-extrabold text-green-700 dark:text-green-300 mt-4 mb-2">{t('growsPage.title')}</h1>
 
       <div className="mt-6">
         {grows.length ? (
@@ -90,8 +92,8 @@ export default function GrowsPage() {
           </ul>
         ) : (
           <div className="text-gray-400 dark:text-gray-500 text-center py-8">
-            Nenhum grow cadastrado ainda.<br />
-            <Link to="/novo-grow" className="underline text-green-700 dark:text-green-300">Crie sua primeira estufa</Link>
+            {t('growsPage.no_grows')}<br />
+            <Link to="/novo-grow" className="underline text-green-700 dark:text-green-300">{t('growsPage.create_first')}</Link>
           </div>
         )}
       </div>

--- a/pages/NovaPlantaPage.tsx
+++ b/pages/NovaPlantaPage.tsx
@@ -5,6 +5,7 @@ import Toast from '../components/Toast';
 import PlantaForm from '../components/PlantaForm';
 import { usePlantContext } from '../contexts/PlantContext';
 import { PlantStage, PlantHealthStatus, PlantOperationalStatus } from '../types';
+import { useTranslation } from 'react-i18next';
 
 export default function NovaPlantaPage() {
   const [searchParams] = useSearchParams();
@@ -13,11 +14,12 @@ export default function NovaPlantaPage() {
   const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' | 'info' } | null>(null);
   const navigate = useNavigate();
   const { addPlant, error: plantContextError } = usePlantContext();
+  const { t } = useTranslation();
 
   // Verifica se há um cultivoId na URL
   useEffect(() => {
     if (!cultivoId) {
-      setToast({ message: 'ID do cultivo não fornecido', type: 'error' });
+      setToast({ message: t('novaPlantaPage.error_no_cultivo'), type: 'error' });
       setTimeout(() => navigate('/cultivos'), 2000);
     }
   }, [cultivoId, navigate]);
@@ -33,7 +35,7 @@ export default function NovaPlantaPage() {
   // Handler para submissão do formulário usando o método principal
   const handlePlantaSubmit = async (values: { name: string; strain: string; birthDate: string; substrate: string }) => {
     if (!cultivoId) {
-      setToast({ message: 'ID do cultivo não encontrado', type: 'error' });
+      setToast({ message: t('novaPlantaPage.error_no_cultivo'), type: 'error' });
       return;
     }
     setSaving(true);
@@ -89,12 +91,12 @@ export default function NovaPlantaPage() {
             </>
           )}
           <span>&gt;</span>
-          <span className="font-bold text-green-700 dark:text-green-300">Nova Planta</span>
+          <span className="font-bold text-green-700 dark:text-green-300">{t('novaPlantaPage.title')}</span>
         </nav>
       </div>
       <div className="bg-white dark:bg-gray-800 shadow-xl rounded-lg p-4 sm:p-6 flex-1 flex flex-col">
         <h1 className="text-2xl sm:text-3xl font-extrabold text-green-700 dark:text-green-300 mb-6 text-center">
-          Adicionar Nova Planta
+          {t('novaPlantaPage.add_new_plant')}
         </h1>
         <PlantaForm onSubmit={handlePlantaSubmit} loading={saving} />
       </div>

--- a/pages/NovoCultivoPage.tsx
+++ b/pages/NovoCultivoPage.tsx
@@ -5,6 +5,7 @@ import ArrowLeftIcon from '../components/icons/ArrowLeftIcon';
 import Toast from '../components/Toast';
 import { SUBSTRATE_OPTIONS } from '../constants';
 import { Grow, PlantStage, PlantHealthStatus, PlantOperationalStatus } from '../types';
+import { useTranslation } from 'react-i18next';
 
 export default function NovoCultivoPage() {
   const [searchParams] = useSearchParams();
@@ -19,6 +20,7 @@ export default function NovoCultivoPage() {
   const [saving, setSaving] = useState(false);
   const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' | 'info' } | null>(null);
   const navigate = useNavigate();
+  const { t } = useTranslation();
 
   useEffect(() => {
     async function fetchGrows() {
@@ -96,35 +98,35 @@ export default function NovoCultivoPage() {
         <nav className="text-xs text-gray-500 dark:text-gray-400 flex gap-1">
           <Link to="/" className="hover:underline">Dashboard</Link>
           <span>&gt;</span>
-          <Link to="/cultivos" className="hover:underline">Cultivos</Link>
+          <Link to="/cultivos" className="hover:underline">{t('sidebar.cultivos')}</Link>
           <span>&gt;</span>
-          <span className="font-bold text-green-700 dark:text-green-300">Novo Cultivo</span>
+          <span className="font-bold text-green-700 dark:text-green-300">{t('novoCultivoPage.title')}</span>
         </nav>
       </div>
 
       <div className="bg-white dark:bg-gray-800 shadow-xl rounded-lg p-4 sm:p-6 flex-1 flex flex-col">
-        <h1 className="text-2xl sm:text-3xl font-extrabold text-green-700 dark:text-green-300 mb-6 text-center">Novo Cultivo</h1>
+        <h1 className="text-2xl sm:text-3xl font-extrabold text-green-700 dark:text-green-300 mb-6 text-center">{t('novoCultivoPage.title')}</h1>
         <form onSubmit={handleSalvarCultivo} className="space-y-6 lg:grid lg:grid-cols-2 lg:gap-6 lg:space-y-0">
           {/* Detalhes do Cultivo */}
           <fieldset className="space-y-4 p-4 border border-gray-200 dark:border-gray-700 rounded-md lg:flex-1">
-            <legend className="text-lg font-semibold text-gray-700 dark:text-gray-300 px-2">Informações do Cultivo</legend>
+            <legend className="text-lg font-semibold text-gray-700 dark:text-gray-300 px-2">{t('novoCultivoPage.info_section')}</legend>
             <div>
-              <label htmlFor="cultivoNome" className={labelStyle}>Nome do Cultivo</label>
+              <label htmlFor="cultivoNome" className={labelStyle}>{t('novoCultivoPage.cultivo_name')}</label>
               <input id="cultivoNome" type="text" className={inputStyle} value={cultivoNome} onChange={e => setCultivoNome(e.target.value)} required />
             </div>
             <div>
-              <label htmlFor="startDate" className={labelStyle}>Data de Início</label>
+              <label htmlFor="startDate" className={labelStyle}>{t('novoCultivoPage.start_date')}</label>
               <input id="startDate" type="date" className={inputStyle} value={startDate} onChange={e => setStartDate(e.target.value)} required />
             </div>
             <div>
-              <label htmlFor="grow" className={labelStyle}>Grow / Estufa</label>
+              <label htmlFor="grow" className={labelStyle}>{t('novoCultivoPage.grow')}</label>
               <select id="grow" className={inputStyle} value={growId} onChange={e => setGrowId(e.target.value)}>
                 <option value="">Selecione...</option>
                 {grows.map(g => <option key={g.id} value={g.id}>{g.name}</option>)}
               </select>
             </div>
             <div>
-              <label htmlFor="substrate" className={labelStyle}>Substrato</label>
+              <label htmlFor="substrate" className={labelStyle}>{t('novoCultivoPage.substrate')}</label>
               <select id="substrate" className={inputStyle} value={substrate} onChange={e => setSubstrate(e.target.value)}>
                 {SUBSTRATE_OPTIONS.map(opt => (
                   <option key={opt.value} value={opt.value}>{opt.label}</option>
@@ -132,13 +134,13 @@ export default function NovoCultivoPage() {
               </select>
             </div>
             <div>
-              <label htmlFor="notes" className={labelStyle}>Notas (opcional)</label>
+              <label htmlFor="notes" className={labelStyle}>{t('novoCultivoPage.notes')}</label>
               <textarea id="notes" className={inputStyle} value={notes} onChange={e => setNotes(e.target.value)} rows={3} />
             </div>
           </fieldset>
 
           <fieldset className="space-y-4 p-4 border border-gray-200 dark:border-gray-700 rounded-md lg:flex-1">
-            <legend className="text-lg font-semibold text-gray-700 dark:text-gray-300 px-2">Plantas</legend>
+            <legend className="text-lg font-semibold text-gray-700 dark:text-gray-300 px-2">{t('novoCultivoPage.plants_section')}</legend>
             {plants.map((p, idx) => (
               <div key={idx} className="grid grid-cols-2 gap-2 items-center">
                 <input
@@ -156,16 +158,16 @@ export default function NovoCultivoPage() {
                   onChange={e => updatePlant(idx, 'strain', e.target.value)}
                 />
                 {plants.length > 1 && (
-                  <button type="button" onClick={() => removePlantField(idx)} className="text-red-500 text-sm">Remover</button>
+                  <button type="button" onClick={() => removePlantField(idx)} className="text-red-500 text-sm">{t('novoCultivoPage.remove')}</button>
                 )}
               </div>
             ))}
-            <button type="button" onClick={addPlantField} className="text-green-700 text-sm">+ Adicionar Planta</button>
+            <button type="button" onClick={addPlantField} className="text-green-700 text-sm">{t('novoCultivoPage.add_plant')}</button>
           </fieldset>
 
           <div className="mt-8 flex justify-center lg:col-span-2">
             <Button type="submit" variant="primary" size="lg" loading={saving} disabled={!cultivoNome || !startDate}>
-              Salvar Cultivo
+              {t('novoCultivoPage.save')}
             </Button>
           </div>
         </form>

--- a/pages/NovoGrowPage.tsx
+++ b/pages/NovoGrowPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, Link } from 'react-router-dom';
 import Button from '../components/Button';
 import ArrowLeftIcon from '../components/icons/ArrowLeftIcon';
 import Toast from '../components/Toast';
+import { useTranslation } from 'react-i18next';
 
 export default function NovoGrowPage() {
   const [name, setName] = useState('');
@@ -11,6 +12,7 @@ export default function NovoGrowPage() {
   const [saving, setSaving] = useState(false);
   const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' | 'info' } | null>(null);
   const navigate = useNavigate();
+  const { t } = useTranslation();
 
   useEffect(() => {
     if (toast) {
@@ -52,24 +54,24 @@ export default function NovoGrowPage() {
         <nav className="text-xs text-gray-500 dark:text-gray-400 flex gap-1">
           <Link to="/" className="hover:underline">Dashboard</Link>
           <span>&gt;</span>
-          <Link to="/grows" className="hover:underline">Grows</Link>
+          <Link to="/grows" className="hover:underline">{t('sidebar.grows')}</Link>
           <span>&gt;</span>
-          <span className="font-bold text-green-700 dark:text-green-300">Novo Grow</span>
+          <span className="font-bold text-green-700 dark:text-green-300">{t('novoGrowPage.title')}</span>
         </nav>
       </div>
       <div className="bg-white dark:bg-gray-800 shadow-xl rounded-lg p-4 sm:p-6 flex-1 flex flex-col">
-        <h1 className="text-2xl sm:text-3xl font-extrabold text-green-700 dark:text-green-300 mb-6 text-center">Novo Grow</h1>
+        <h1 className="text-2xl sm:text-3xl font-extrabold text-green-700 dark:text-green-300 mb-6 text-center">{t('novoGrowPage.title')}</h1>
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label htmlFor="growName" className={labelStyle}>Nome do Grow</label>
+            <label htmlFor="growName" className={labelStyle}>{t('novoGrowPage.name')}</label>
             <input id="growName" type="text" className={inputStyle} value={name} onChange={e => setName(e.target.value)} required />
           </div>
           <div>
-            <label htmlFor="growLocation" className={labelStyle}>Localização (opcional)</label>
+            <label htmlFor="growLocation" className={labelStyle}>{t('novoGrowPage.location')}</label>
             <input id="growLocation" type="text" className={inputStyle} value={location} onChange={e => setLocation(e.target.value)} />
           </div>
           <div>
-            <label htmlFor="growCapacity" className={labelStyle}>Capacidade (opcional)</label>
+            <label htmlFor="growCapacity" className={labelStyle}>{t('novoGrowPage.capacity')}</label>
             <input
               id="growCapacity"
               type="number"
@@ -80,7 +82,7 @@ export default function NovoGrowPage() {
             />
           </div>
           <div className="mt-6 flex justify-center">
-            <Button type="submit" variant="primary" size="lg" loading={saving} disabled={!name}>Salvar Grow</Button>
+            <Button type="submit" variant="primary" size="lg" loading={saving} disabled={!name}>{t('novoGrowPage.save')}</Button>
           </div>
         </form>
       </div>

--- a/pages/PlantDetailPage.tsx
+++ b/pages/PlantDetailPage.tsx
@@ -12,10 +12,12 @@ import Sidebar from '../components/Sidebar';
 import Header from '../components/Header';
 import LeafIcon from '../components/icons/LeafIcon';
 import Toast from '../components/Toast';
+import { useTranslation } from 'react-i18next';
 
 const PlantDetailPage: React.FC = () => {
   const { plantId } = useParams<{ plantId: string }>();
   const navigate = useNavigate();
+  const { t } = useTranslation();
   const {
     getPlantById,
     fetchPlantById,
@@ -284,7 +286,7 @@ const PlantDetailPage: React.FC = () => {
         <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
         <div className="flex-1 flex flex-col min-h-full">
         <Header
-          title="Detalhes da Planta"
+          title={t('plantDetailPage.title')}
           onOpenSidebar={() => setSidebarOpen(true)}
           onOpenAddModal={() => {}}
           onOpenScannerModal={() => {}}
@@ -395,7 +397,7 @@ const PlantDetailPage: React.FC = () => {
 
               <section className="lg:col-span-2 flex flex-col gap-6">
                 <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow">
-                  <h2 className="text-xl font-semibold text-gray-700 dark:text-gray-300 mb-4">Checklist Diário</h2>
+                  <h2 className="text-xl font-semibold text-gray-700 dark:text-gray-300 mb-4">{t('plantDetailPage.daily_checklist')}</h2>
                   <DailyChecklist
                     stage={plant.currentStage}
                     checklistState={checklistState}
@@ -404,12 +406,12 @@ const PlantDetailPage: React.FC = () => {
                 </div>
                 <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow">
                   <div className="flex items-center justify-between mb-4">
-                    <h2 className="text-xl font-semibold text-gray-700 dark:text-gray-300">Diário da Planta</h2>
+                  <h2 className="text-xl font-semibold text-gray-700 dark:text-gray-300">{t('plantDetailPage.diary')}</h2>
                     <button
                       onClick={() => setShowDiaryEntryModal(true)}
                       className="px-4 py-2 bg-green-600 text-white font-semibold rounded-lg hover:bg-green-700 transition-colors"
                     >
-                      Nova Entrada
+                      {t('plantDetailPage.new_entry')}
                     </button>
                   </div>
                   {diaryEntries.length > 0 ? (
@@ -428,7 +430,7 @@ const PlantDetailPage: React.FC = () => {
           <Modal
             isOpen={showDiaryEntryModal}
             onClose={() => setShowDiaryEntryModal(false)}
-            title="Nova Entrada no Diário"
+            title={t('plantDetailPage.new_entry')}
             maxWidth="md"
           >
             {plant && (
@@ -443,12 +445,12 @@ const PlantDetailPage: React.FC = () => {
           <Modal
             isOpen={showRemoveByDiseaseModal}
             onClose={() => setShowRemoveByDiseaseModal(false)}
-            title="Remover Planta por Doença"
+            title={t('plantDetailPage.remove_disease')}
           >
             <div className="p-1">
-              <p className="mb-3 text-gray-700 dark:text-gray-300">Tem certeza que deseja remover esta planta por doença?</p>
+              <p className="mb-3 text-gray-700 dark:text-gray-300">{t('plantDetailPage.confirm_remove')}</p>
               <textarea
-                placeholder="Motivo ou observação (opcional)"
+                placeholder={t('plantDetailPage.reason_optional')}
                 value={removeByDiseaseNote}
                 onChange={e => setRemoveByDiseaseNote(e.target.value)}
                 className="w-full p-2 border border-gray-300 dark:border-gray-600 rounded-md min-h-[60px] mb-4 bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-200"
@@ -477,7 +479,7 @@ const PlantDetailPage: React.FC = () => {
                   onClick={handleDownloadQrCode}
                   className="w-full max-w-[180px] bg-green-500 hover:bg-green-600 text-white font-semibold py-2 px-4 rounded-lg transition-colors"
                 >
-                  Baixar QR Code
+                  {t('plantDetailPage.download_qr')}
                 </button>
               </div>
             </Modal>

--- a/pages/PlantStatisticsPage.tsx
+++ b/pages/PlantStatisticsPage.tsx
@@ -13,6 +13,7 @@ import {
 } from '../constants';
 import ChevronDownIcon from '../components/icons/ChevronDownIcon';
 import ChevronUpIcon from '../components/icons/ChevronUpIcon';
+import { useTranslation } from 'react-i18next';
 
 const PlantStatisticsPage: React.FC = () => {
   const { plantId } = useParams<{ plantId: string }>();
@@ -20,6 +21,7 @@ const PlantStatisticsPage: React.FC = () => {
   const [plant, setPlant] = useState<Plant | null | undefined>(null);
   const [isLoadingLocal, setIsLoadingLocal] = useState(false);
   const [showExtraDetails, setShowExtraDetails] = useState(false);
+  const { t } = useTranslation();
 
   const loadPlantData = useCallback(async () => {
     if (!plantId) return;
@@ -54,12 +56,12 @@ const PlantStatisticsPage: React.FC = () => {
   return (
     <div className="p-4 bg-slate-900 min-h-full text-slate-100 space-y-8 w-full">
       <div className="flex justify-between items-center">
-        <h1 className="text-3xl font-bold text-green-400">Estatísticas de {plant.name}</h1>
+        <h1 className="text-3xl font-bold text-green-400">{t('plantStatisticsPage.title', { name: plant.name })}</h1>
         <Link 
           to={`/plant/${plantId}`}
           className="bg-slate-700 hover:bg-slate-600 text-white font-semibold px-4 py-2 rounded-lg shadow transition-colors"
         >
-          Voltar aos Detalhes
+          {t('plantStatisticsPage.back')}
         </Link>
       </div>
       
@@ -111,7 +113,7 @@ const PlantStatisticsPage: React.FC = () => {
           aria-expanded={showExtraDetails}
           className="w-full flex justify-between items-center p-4 sm:p-5 text-left text-lg font-semibold text-[#7AC943] hover:bg-green-50 dark:hover:bg-slate-700/50 transition-colors duration-150 rounded-t-xl focus:outline-none"
         >
-          Mais Detalhes da Planta
+          {t('plantStatisticsPage.more_details')}
           {showExtraDetails ? <ChevronUpIcon className="w-6 h-6 text-[#7AC943]" /> : <ChevronDownIcon className="w-6 h-6 text-[#7AC943]" />}
         </button>
         {showExtraDetails && (


### PR DESCRIPTION
## Summary
- integrate `useTranslation` in various pages
- replace strings with translation keys
- expand translation files with new sections

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68497e34a048832aaec98e935c5c37d6