### PR TITLE
Add Breadcrumbs component

### DIFF
--- a/components/Breadcrumbs.tsx
+++ b/components/Breadcrumbs.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+export interface BreadcrumbItem {
+  label: string;
+  to?: string;
+}
+
+interface BreadcrumbsProps {
+  items: BreadcrumbItem[];
+  className?: string;
+}
+
+const Breadcrumbs: React.FC<BreadcrumbsProps> = ({ items, className }) => {
+  return (
+    <nav className={`text-xs text-gray-500 dark:text-gray-400 flex gap-1 ${className ?? ''}`.trim()}>
+      {items.map((item, idx) => (
+        <React.Fragment key={idx}>
+          {idx > 0 && <span>&gt;</span>}
+          {item.to ? (
+            <Link to={item.to} className="hover:underline">
+              {item.label}
+            </Link>
+          ) : (
+            <span className="font-bold text-green-700 dark:text-green-300">
+              {item.label}
+            </span>
+          )}
+        </React.Fragment>
+      ))}
+    </nav>
+  );
+};
+
+export default Breadcrumbs;

--- a/pages/CultivoDetailPage.tsx
+++ b/pages/CultivoDetailPage.tsx
@@ -11,6 +11,7 @@ import ArrowLeftIcon from '../components/icons/ArrowLeftIcon';
 import CheckCircleIcon from '../components/icons/CheckCircleIcon';
 import LeafIcon from '../components/icons/LeafIcon';
 import PlusIcon from '../components/icons/PlusIcon';
+import Breadcrumbs from '../components/Breadcrumbs';
 import { getPlantsByCultivo, updateCultivo } from '../services/cultivoService';
 import { getGrows } from '../services/growService';
 import { updatePlant } from '../services/plantService';
@@ -271,13 +272,13 @@ const CultivoDetailPage: React.FC = () => {
         >
           <ArrowLeftIcon className="w-7 h-7 text-green-700" />
         </button>
-        <nav className="text-xs text-gray-500 dark:text-gray-400 flex gap-1">
-          <Link to="/" className="hover:underline">Dashboard</Link>
-          <span>&gt;</span>
-          <Link to="/cultivos" className="hover:underline">Cultivos</Link>
-          <span>&gt;</span>
-          <span className="font-bold text-green-700 dark:text-green-300">{cultivo.name}</span>
-        </nav>
+        <Breadcrumbs
+          items={[
+            { label: 'Dashboard', to: '/' },
+            { label: 'Cultivos', to: '/cultivos' },
+            { label: cultivo.name },
+          ]}
+        />
       </div>
 
       {/* Título e status */}

--- a/pages/GrowDetailPage.tsx
+++ b/pages/GrowDetailPage.tsx
@@ -7,6 +7,7 @@ import Button from '../components/Button';
 import Loader from '../components/Loader';
 import Toast from '../components/Toast';
 import Modal from '../components/Modal';
+import Breadcrumbs from '../components/Breadcrumbs';
 import GrowQrCodeDisplay from '../components/GrowQrCodeDisplay';
 import { addMassDiaryEntry } from '../services/plantService';
 
@@ -108,13 +109,13 @@ export default function GrowDetailPage() {
         >
           <ArrowLeftIcon className="w-7 h-7 text-green-700" />
         </button>
-        <nav className="text-xs text-gray-500 dark:text-gray-400 flex gap-1">
-          <Link to="/" className="hover:underline">Dashboard</Link>
-          <span>&gt;</span>
-          <Link to="/grows" className="hover:underline">Grows</Link>
-          <span>&gt;</span>
-          <span className="font-bold text-green-700 dark:text-green-300">{grow.name}</span>
-        </nav>
+        <Breadcrumbs
+          items={[
+            { label: 'Dashboard', to: '/' },
+            { label: 'Grows', to: '/grows' },
+            { label: grow.name },
+          ]}
+        />
         <div className="flex-1" />
         <Link to={`/novo-cultivo?growId=${grow.id}`}>
           <Button variant="primary" size="icon" className="shadow" title="Novo Plantio">

--- a/pages/NovaPlantaPage.tsx
+++ b/pages/NovaPlantaPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import ArrowLeftIcon from '../components/icons/ArrowLeftIcon';
 import Toast from '../components/Toast';
 import PlantaForm from '../components/PlantaForm';
+import Breadcrumbs from '../components/Breadcrumbs';
 import { usePlantContext } from '../contexts/PlantContext';
 import { PlantStage, PlantHealthStatus, PlantOperationalStatus } from '../types';
 
@@ -73,24 +74,14 @@ export default function NovaPlantaPage() {
         >
           <ArrowLeftIcon className="w-7 h-7 text-green-700" />
         </button>
-        <nav className="text-xs text-gray-500 dark:text-gray-400 flex gap-1">
-          <button onClick={() => navigate('/')} className="hover:underline">Dashboard</button>
-          <span>&gt;</span>
-          <button onClick={() => navigate('/cultivos')} className="hover:underline">Cultivos</button>
-          {cultivoId && (
-            <>
-              <span>&gt;</span>
-              <button 
-                onClick={() => navigate(`/cultivo/${cultivoId}`)} 
-                className="hover:underline"
-              >
-                Cultivo
-              </button>
-            </>
-          )}
-          <span>&gt;</span>
-          <span className="font-bold text-green-700 dark:text-green-300">Nova Planta</span>
-        </nav>
+        <Breadcrumbs
+          items={[
+            { label: 'Dashboard', to: '/' },
+            { label: 'Cultivos', to: '/cultivos' },
+            ...(cultivoId ? [{ label: 'Cultivo', to: `/cultivo/${cultivoId}` }] : []),
+            { label: 'Nova Planta' },
+          ]}
+        />
       </div>
       <div className="bg-white dark:bg-gray-800 shadow-xl rounded-lg p-4 sm:p-6 flex-1 flex flex-col">
         <h1 className="text-2xl sm:text-3xl font-extrabold text-green-700 dark:text-green-300 mb-6 text-center">

--- a/pages/NovoCultivoPage.tsx
+++ b/pages/NovoCultivoPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, Link, useSearchParams } from 'react-router-dom';
 import Button from '../components/Button';
 import ArrowLeftIcon from '../components/icons/ArrowLeftIcon';
 import Toast from '../components/Toast';
+import Breadcrumbs from '../components/Breadcrumbs';
 import { SUBSTRATE_OPTIONS } from '../constants';
 import { Grow, PlantStage, PlantHealthStatus, PlantOperationalStatus } from '../types';
 
@@ -93,13 +94,13 @@ export default function NovoCultivoPage() {
         >
           <ArrowLeftIcon className="w-7 h-7 text-green-700" />
         </button>
-        <nav className="text-xs text-gray-500 dark:text-gray-400 flex gap-1">
-          <Link to="/" className="hover:underline">Dashboard</Link>
-          <span>&gt;</span>
-          <Link to="/cultivos" className="hover:underline">Cultivos</Link>
-          <span>&gt;</span>
-          <span className="font-bold text-green-700 dark:text-green-300">Novo Cultivo</span>
-        </nav>
+        <Breadcrumbs
+          items={[
+            { label: 'Dashboard', to: '/' },
+            { label: 'Cultivos', to: '/cultivos' },
+            { label: 'Novo Cultivo' },
+          ]}
+        />
       </div>
 
       <div className="bg-white dark:bg-gray-800 shadow-xl rounded-lg p-4 sm:p-6 flex-1 flex flex-col">

--- a/pages/NovoGrowPage.tsx
+++ b/pages/NovoGrowPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, Link } from 'react-router-dom';
 import Button from '../components/Button';
 import ArrowLeftIcon from '../components/icons/ArrowLeftIcon';
 import Toast from '../components/Toast';
+import Breadcrumbs from '../components/Breadcrumbs';
 
 export default function NovoGrowPage() {
   const [name, setName] = useState('');
@@ -49,13 +50,13 @@ export default function NovoGrowPage() {
         >
           <ArrowLeftIcon className="w-7 h-7 text-green-700" />
         </button>
-        <nav className="text-xs text-gray-500 dark:text-gray-400 flex gap-1">
-          <Link to="/" className="hover:underline">Dashboard</Link>
-          <span>&gt;</span>
-          <Link to="/grows" className="hover:underline">Grows</Link>
-          <span>&gt;</span>
-          <span className="font-bold text-green-700 dark:text-green-300">Novo Grow</span>
-        </nav>
+        <Breadcrumbs
+          items={[
+            { label: 'Dashboard', to: '/' },
+            { label: 'Grows', to: '/grows' },
+            { label: 'Novo Grow' },
+          ]}
+        />
       </div>
       <div className="bg-white dark:bg-gray-800 shadow-xl rounded-lg p-4 sm:p-6 flex-1 flex flex-col">
         <h1 className="text-2xl sm:text-3xl font-extrabold text-green-700 dark:text-green-300 mb-6 text-center">Novo Grow</h1>


### PR DESCRIPTION
## Summary
- create a Breadcrumbs component
- use Breadcrumbs across page headers

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68497e3bf9dc832a9c69d1116726ef82