### PR TITLE
Refactor pages with Header/Breadcrumbs

### DIFF
--- a/components/Breadcrumbs.tsx
+++ b/components/Breadcrumbs.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+export interface BreadcrumbItem {
+  label: React.ReactNode;
+  to?: string;
+}
+
+interface BreadcrumbsProps {
+  items: BreadcrumbItem[];
+  className?: string;
+}
+
+const Breadcrumbs: React.FC<BreadcrumbsProps> = ({ items, className }) => {
+  return (
+    <nav className={`text-xs text-gray-500 dark:text-gray-400 flex gap-1 ${className || ''}`.trim()}>
+      {items.map((item, idx) => (
+        <React.Fragment key={idx}>
+          {idx < items.length - 1 ? (
+            item.to ? (
+              <Link to={item.to} className="hover:underline">
+                {item.label}
+              </Link>
+            ) : (
+              <span>{item.label}</span>
+            )
+          ) : (
+            <span className="font-bold text-green-700 dark:text-green-300">
+              {item.label}
+            </span>
+          )}
+          {idx < items.length - 1 && <span>&gt;</span>}
+        </React.Fragment>
+      ))}
+    </nav>
+  );
+};
+
+export default Breadcrumbs;

--- a/pages/AllPlantsPage.tsx
+++ b/pages/AllPlantsPage.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { useNavigate, Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { usePlantContext } from '../contexts/PlantContext';
 import PlantCard from '../components/PlantCard';
 import Loader from '../components/Loader';
 import Header from '../components/Header';
+import Breadcrumbs from '../components/Breadcrumbs';
 import Sidebar from '../components/Sidebar';
 import Button from '../components/Button';
 import Toast from '../components/Toast';
@@ -86,15 +87,12 @@ const AllPlantsPage: React.FC = () => {
           />
           <Container sx={{ py: 4 }}>
             <Box display="flex" alignItems="center" mb={2}>
-              <Link to="/" style={{ textDecoration: 'none' }}>
-                <Typography variant="body2" color="text.secondary">Dashboard</Typography>
-              </Link>
-              <Typography variant="body2" color="text.secondary" sx={{ mx: 1 }}>
-                &gt;
-              </Typography>
-              <Typography variant="body2" fontWeight="bold">
-                Todas as Plantas
-              </Typography>
+              <Breadcrumbs
+                items={[
+                  { label: 'Dashboard', to: '/' },
+                  { label: 'Todas as Plantas' },
+                ]}
+              />
               <Box sx={{ flexGrow: 1 }} />
               {!selectionMode && plants.length > 0 && (
                 <Button variant="secondary" onClick={() => setSelectionMode(true)}>

--- a/pages/CultivoDetailPage.tsx
+++ b/pages/CultivoDetailPage.tsx
@@ -7,7 +7,8 @@ import Modal from '../components/Modal';
 import Toast from '../components/Toast';
 import Loader from "../components/Loader";
 import PlantCard from '../components/PlantCard';
-import ArrowLeftIcon from '../components/icons/ArrowLeftIcon';
+import Header from '../components/Header';
+import Breadcrumbs from '../components/Breadcrumbs';
 import CheckCircleIcon from '../components/icons/CheckCircleIcon';
 import LeafIcon from '../components/icons/LeafIcon';
 import PlusIcon from '../components/icons/PlusIcon';
@@ -262,23 +263,22 @@ const CultivoDetailPage: React.FC = () => {
       {/* Toast global */}
       {toast && <Toast message={toast.message} type={toast.type} />}
 
-      {/* Breadcrumbs e botão de voltar mobile first */}
-      <div className="sticky top-0 z-20 bg-white/80 dark:bg-slate-900/80 flex items-center gap-2 py-2 px-1 sm:px-0 -mx-2 sm:mx-0 backdrop-blur-md">
-        <button
-          onClick={() => navigate(-1)}
-          className="p-2 rounded-full hover:bg-green-100 dark:hover:bg-green-900 transition focus:outline-none focus:ring-2 focus:ring-green-400"
-          aria-label="Voltar"
-        >
-          <ArrowLeftIcon className="w-7 h-7 text-green-700" />
-        </button>
-        <nav className="text-xs text-gray-500 dark:text-gray-400 flex gap-1">
-          <Link to="/" className="hover:underline">Dashboard</Link>
-          <span>&gt;</span>
-          <Link to="/cultivos" className="hover:underline">Cultivos</Link>
-          <span>&gt;</span>
-          <span className="font-bold text-green-700 dark:text-green-300">{cultivo.name}</span>
-        </nav>
-      </div>
+      <Header
+        title={cultivo.name}
+        onOpenSidebar={() => {}}
+        onOpenAddModal={() => navigate(`/nova-planta?cultivoId=${cultivo.id}`)}
+        onOpenScannerModal={() => {}}
+        showBack
+        onBack={() => navigate(-1)}
+      />
+      <Breadcrumbs
+        items={[
+          { label: 'Dashboard', to: '/' },
+          { label: 'Cultivos', to: '/cultivos' },
+          { label: cultivo.name },
+        ]}
+        className="px-1 sm:px-0"
+      />
 
       {/* Título e status */}
       <div className="flex items-center gap-2 mt-2 mb-1">

--- a/pages/CultivosPage.tsx
+++ b/pages/CultivosPage.tsx
@@ -4,7 +4,8 @@ import { useTranslation } from 'react-i18next';
 import { Box, Container, Grid, Paper, Typography } from '@mui/material';
 import { Cultivo } from '../types';
 import Button from '../components/Button';
-import ArrowLeftIcon from '../components/icons/ArrowLeftIcon';
+import Header from '../components/Header';
+import Breadcrumbs from '../components/Breadcrumbs';
 import Toast from '../components/Toast';
 import LeafIcon from '../components/icons/LeafIcon';
 import Loader from '../components/Loader';
@@ -65,24 +66,21 @@ const CultivosPage: React.FC = () => {
     <Container maxWidth="sm" sx={{ py: 2 }}>
       {toast && <Toast message={toast.message} type={toast.type} />}
 
-      <Box sx={{ position: 'sticky', top: 0, bgcolor: 'background.default', zIndex: 20, py: 1, display: 'flex', alignItems: 'center', gap: 1 }}>
-        <Button variant="ghost" size="icon" onClick={() => navigate(-1)} aria-label="Voltar">
-          <ArrowLeftIcon className="w-6 h-6" />
-        </Button>
-        <Link to="/" style={{ textDecoration: 'none' }}>
-          <Typography variant="body2" color="text.secondary">Dashboard</Typography>
-        </Link>
-        <Typography variant="body2" color="text.secondary" sx={{ mx: 0.5 }}>
-          &gt;
-        </Typography>
-        <Typography variant="body2" fontWeight="bold" color="primary.main">
-          {t('sidebar.cultivos')}
-        </Typography>
-        <Box sx={{ flexGrow: 1 }} />
-        <Button variant="primary" size="icon" onClick={() => navigate('/novo-cultivo')} title={t('cultivosPage.new_cultivo')}>
-          <Typography component="span" sx={{ fontSize: 20, fontWeight: 'bold', lineHeight: 1 }}>+</Typography>
-        </Button>
-      </Box>
+      <Header
+        title={t('sidebar.cultivos')}
+        onOpenSidebar={() => {}}
+        onOpenAddModal={() => navigate('/novo-cultivo')}
+        onOpenScannerModal={() => {}}
+        showBack
+        onBack={() => navigate(-1)}
+      />
+      <Breadcrumbs
+        items={[
+          { label: 'Dashboard', to: '/' },
+          { label: t('sidebar.cultivos') },
+        ]}
+        className="mb-2"
+      />
 
       <Typography variant="h5" fontWeight="bold" color="primary.main" sx={{ mt: 3, mb: 2 }}>
         {hasCultivos ? t('cultivosPage.title_with_count', { count: cultivos.length }) : t('cultivosPage.title')}

--- a/pages/GrowDetailPage.tsx
+++ b/pages/GrowDetailPage.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
 import { Grow, Cultivo, PlantStage } from '../types';
-import ArrowLeftIcon from '../components/icons/ArrowLeftIcon';
 import PlusIcon from '../components/icons/PlusIcon';
 import Button from '../components/Button';
+import Header from '../components/Header';
+import Breadcrumbs from '../components/Breadcrumbs';
 import Loader from '../components/Loader';
 import Toast from '../components/Toast';
 import Modal from '../components/Modal';
@@ -100,28 +101,22 @@ export default function GrowDetailPage() {
   return (
     <div className="max-w-lg mx-auto w-full min-h-full flex flex-col gap-3 bg-white dark:bg-slate-900 p-2 sm:p-4">
       {toast && <Toast message={toast.message} type={toast.type} />}
-      <div className="sticky top-0 z-20 bg-white/80 dark:bg-slate-900/80 flex items-center gap-2 py-2 px-1 sm:px-0 -mx-2 sm:mx-0 backdrop-blur-md mb-2">
-        <button
-          onClick={() => navigate(-1)}
-          className="p-2 rounded-full hover:bg-green-100 dark:hover:bg-green-900 transition focus:outline-none focus:ring-2 focus:ring-green-400"
-          aria-label="Voltar"
-        >
-          <ArrowLeftIcon className="w-7 h-7 text-green-700" />
-        </button>
-        <nav className="text-xs text-gray-500 dark:text-gray-400 flex gap-1">
-          <Link to="/" className="hover:underline">Dashboard</Link>
-          <span>&gt;</span>
-          <Link to="/grows" className="hover:underline">Grows</Link>
-          <span>&gt;</span>
-          <span className="font-bold text-green-700 dark:text-green-300">{grow.name}</span>
-        </nav>
-        <div className="flex-1" />
-        <Link to={`/novo-cultivo?growId=${grow.id}`}>
-          <Button variant="primary" size="icon" className="shadow" title="Novo Plantio">
-            <PlusIcon className="w-5 h-5" />
-          </Button>
-        </Link>
-      </div>
+      <Header
+        title="Detalhes do Grow"
+        onOpenSidebar={() => {}}
+        onOpenAddModal={() => navigate(`/novo-cultivo?growId=${grow.id}`)}
+        onOpenScannerModal={() => {}}
+        showBack
+        onBack={() => navigate(-1)}
+      />
+      <Breadcrumbs
+        items={[
+          { label: 'Dashboard', to: '/' },
+          { label: 'Grows', to: '/grows' },
+          { label: grow.name },
+        ]}
+        className="px-1 sm:px-0 mb-2"
+      />
 
       <h1 className="text-2xl font-extrabold text-green-700 dark:text-green-300 mt-2 mb-2">{grow.name}</h1>
       {grow.location && <p className="text-sm text-gray-500 dark:text-gray-400">{grow.location}</p>}

--- a/pages/GrowsPage.tsx
+++ b/pages/GrowsPage.tsx
@@ -1,9 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { Grow } from '../types';
 import { Link, useNavigate } from 'react-router-dom';
-import Button from '../components/Button';
-import ArrowLeftIcon from '../components/icons/ArrowLeftIcon';
-import PlusIcon from '../components/icons/PlusIcon';
+import Header from '../components/Header';
+import Breadcrumbs from '../components/Breadcrumbs';
 import Toast from '../components/Toast';
 import Loader from "../components/Loader";
 
@@ -52,26 +51,21 @@ export default function GrowsPage() {
   return (
     <div className="max-w-lg mx-auto w-full min-h-full flex flex-col gap-3 bg-white dark:bg-slate-900 p-2 sm:p-4">
       {toast && <Toast message={toast.message} type={toast.type} />}
-      <div className="sticky top-0 z-20 bg-white/80 dark:bg-slate-900/80 flex items-center gap-2 py-2 px-1 sm:px-0 -mx-2 sm:mx-0 backdrop-blur-md mb-2">
-        <button
-          onClick={() => navigate(-1)}
-          className="p-2 rounded-full hover:bg-green-100 dark:hover:bg-green-900 transition focus:outline-none focus:ring-2 focus:ring-green-400"
-          aria-label="Voltar"
-        >
-          <ArrowLeftIcon className="w-7 h-7 text-green-700" />
-        </button>
-        <nav className="text-xs text-gray-500 dark:text-gray-400 flex gap-1">
-          <Link to="/" className="hover:underline">Dashboard</Link>
-          <span>&gt;</span>
-          <span className="font-bold text-green-700 dark:text-green-300">Grows</span>
-        </nav>
-        <div className="flex-1" />
-        <Link to="/novo-grow">
-          <Button variant="primary" size="icon" className="shadow" title="Novo Grow">
-            <PlusIcon className="w-5 h-5" />
-          </Button>
-        </Link>
-      </div>
+      <Header
+        title="Grows"
+        onOpenSidebar={() => {}}
+        onOpenAddModal={() => navigate('/novo-grow')}
+        onOpenScannerModal={() => {}}
+        showBack
+        onBack={() => navigate(-1)}
+      />
+      <Breadcrumbs
+        items={[
+          { label: 'Dashboard', to: '/' },
+          { label: 'Grows' },
+        ]}
+        className="px-1 sm:px-0 mb-2"
+      />
 
       <h1 className="text-2xl font-extrabold text-green-700 dark:text-green-300 mt-4 mb-2">Meus Grows</h1>
 

--- a/pages/NovaPlantaPage.tsx
+++ b/pages/NovaPlantaPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import ArrowLeftIcon from '../components/icons/ArrowLeftIcon';
+import Header from '../components/Header';
+import Breadcrumbs from '../components/Breadcrumbs';
 import Toast from '../components/Toast';
 import PlantaForm from '../components/PlantaForm';
 import { usePlantContext } from '../contexts/PlantContext';
@@ -65,33 +66,23 @@ export default function NovaPlantaPage() {
   return (
     <div className="max-w-lg mx-auto w-full min-h-full flex flex-col gap-3 bg-white dark:bg-slate-900 p-2 sm:p-4">
       {toast && <Toast message={toast.message} type={toast.type} />}
-      <div className="sticky top-0 z-20 bg-white/80 dark:bg-slate-900/80 flex items-center gap-2 py-2 px-1 sm:px-0 -mx-2 sm:mx-0 backdrop-blur-md mb-2">
-        <button
-          onClick={() => navigate(-1)}
-          className="p-2 rounded-full hover:bg-green-100 dark:hover:bg-green-900 transition focus:outline-none focus:ring-2 focus:ring-green-400"
-          aria-label="Voltar"
-        >
-          <ArrowLeftIcon className="w-7 h-7 text-green-700" />
-        </button>
-        <nav className="text-xs text-gray-500 dark:text-gray-400 flex gap-1">
-          <button onClick={() => navigate('/')} className="hover:underline">Dashboard</button>
-          <span>&gt;</span>
-          <button onClick={() => navigate('/cultivos')} className="hover:underline">Cultivos</button>
-          {cultivoId && (
-            <>
-              <span>&gt;</span>
-              <button 
-                onClick={() => navigate(`/cultivo/${cultivoId}`)} 
-                className="hover:underline"
-              >
-                Cultivo
-              </button>
-            </>
-          )}
-          <span>&gt;</span>
-          <span className="font-bold text-green-700 dark:text-green-300">Nova Planta</span>
-        </nav>
-      </div>
+      <Header
+        title="Nova Planta"
+        onOpenSidebar={() => {}}
+        onOpenAddModal={() => {}}
+        onOpenScannerModal={() => {}}
+        showBack
+        onBack={() => navigate(-1)}
+      />
+      <Breadcrumbs
+        items={[
+          { label: 'Dashboard', to: '/' },
+          { label: 'Cultivos', to: '/cultivos' },
+          ...(cultivoId ? [{ label: 'Cultivo', to: `/cultivo/${cultivoId}` }] : []),
+          { label: 'Nova Planta' },
+        ]}
+        className="px-1 sm:px-0 mb-2"
+      />
       <div className="bg-white dark:bg-gray-800 shadow-xl rounded-lg p-4 sm:p-6 flex-1 flex flex-col">
         <h1 className="text-2xl sm:text-3xl font-extrabold text-green-700 dark:text-green-300 mb-6 text-center">
           Adicionar Nova Planta

--- a/pages/NovoCultivoPage.tsx
+++ b/pages/NovoCultivoPage.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, Link, useSearchParams } from 'react-router-dom';
 import Button from '../components/Button';
-import ArrowLeftIcon from '../components/icons/ArrowLeftIcon';
+import Header from '../components/Header';
+import Breadcrumbs from '../components/Breadcrumbs';
 import Toast from '../components/Toast';
 import { SUBSTRATE_OPTIONS } from '../constants';
 import { Grow, PlantStage, PlantHealthStatus, PlantOperationalStatus } from '../types';
@@ -84,23 +85,22 @@ export default function NovoCultivoPage() {
       {/* Toast global */}
       {toast && <Toast message={toast.message} type={toast.type} />}
 
-      {/* Breadcrumbs e botão de voltar */}
-      <div className="sticky top-0 z-20 bg-white/80 dark:bg-slate-900/80 flex items-center gap-2 py-2 px-1 sm:px-0 -mx-2 sm:mx-0 backdrop-blur-md mb-2">
-        <button
-          onClick={() => navigate(-1)}
-          className="p-2 rounded-full hover:bg-green-100 dark:hover:bg-green-900 transition focus:outline-none focus:ring-2 focus:ring-green-400"
-          aria-label="Voltar"
-        >
-          <ArrowLeftIcon className="w-7 h-7 text-green-700" />
-        </button>
-        <nav className="text-xs text-gray-500 dark:text-gray-400 flex gap-1">
-          <Link to="/" className="hover:underline">Dashboard</Link>
-          <span>&gt;</span>
-          <Link to="/cultivos" className="hover:underline">Cultivos</Link>
-          <span>&gt;</span>
-          <span className="font-bold text-green-700 dark:text-green-300">Novo Cultivo</span>
-        </nav>
-      </div>
+      <Header
+        title="Novo Cultivo"
+        onOpenSidebar={() => {}}
+        onOpenAddModal={() => {}}
+        onOpenScannerModal={() => {}}
+        showBack
+        onBack={() => navigate(-1)}
+      />
+      <Breadcrumbs
+        items={[
+          { label: 'Dashboard', to: '/' },
+          { label: 'Cultivos', to: '/cultivos' },
+          { label: 'Novo Cultivo' },
+        ]}
+        className="px-1 sm:px-0 mb-2"
+      />
 
       <div className="bg-white dark:bg-gray-800 shadow-xl rounded-lg p-4 sm:p-6 flex-1 flex flex-col">
         <h1 className="text-2xl sm:text-3xl font-extrabold text-green-700 dark:text-green-300 mb-6 text-center">Novo Cultivo</h1>

--- a/pages/NovoGrowPage.tsx
+++ b/pages/NovoGrowPage.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import Button from '../components/Button';
-import ArrowLeftIcon from '../components/icons/ArrowLeftIcon';
+import Header from '../components/Header';
+import Breadcrumbs from '../components/Breadcrumbs';
 import Toast from '../components/Toast';
 
 export default function NovoGrowPage() {
@@ -41,22 +42,22 @@ export default function NovoGrowPage() {
   return (
     <div className="max-w-lg mx-auto w-full min-h-full flex flex-col gap-3 bg-white dark:bg-slate-900 p-2 sm:p-4">
       {toast && <Toast message={toast.message} type={toast.type} />}
-      <div className="sticky top-0 z-20 bg-white/80 dark:bg-slate-900/80 flex items-center gap-2 py-2 px-1 sm:px-0 -mx-2 sm:mx-0 backdrop-blur-md mb-2">
-        <button
-          onClick={() => navigate(-1)}
-          className="p-2 rounded-full hover:bg-green-100 dark:hover:bg-green-900 transition focus:outline-none focus:ring-2 focus:ring-green-400"
-          aria-label="Voltar"
-        >
-          <ArrowLeftIcon className="w-7 h-7 text-green-700" />
-        </button>
-        <nav className="text-xs text-gray-500 dark:text-gray-400 flex gap-1">
-          <Link to="/" className="hover:underline">Dashboard</Link>
-          <span>&gt;</span>
-          <Link to="/grows" className="hover:underline">Grows</Link>
-          <span>&gt;</span>
-          <span className="font-bold text-green-700 dark:text-green-300">Novo Grow</span>
-        </nav>
-      </div>
+      <Header
+        title="Novo Grow"
+        onOpenSidebar={() => {}}
+        onOpenAddModal={() => {}}
+        onOpenScannerModal={() => {}}
+        showBack
+        onBack={() => navigate(-1)}
+      />
+      <Breadcrumbs
+        items={[
+          { label: 'Dashboard', to: '/' },
+          { label: 'Grows', to: '/grows' },
+          { label: 'Novo Grow' },
+        ]}
+        className="px-1 sm:px-0 mb-2"
+      />
       <div className="bg-white dark:bg-gray-800 shadow-xl rounded-lg p-4 sm:p-6 flex-1 flex flex-col">
         <h1 className="text-2xl sm:text-3xl font-extrabold text-green-700 dark:text-green-300 mb-6 text-center">Novo Grow</h1>
         <form onSubmit={handleSubmit} className="space-y-4">


### PR DESCRIPTION
## Summary
- add Breadcrumbs component
- switch pages to use `<Header>`
- add breadcrumb navigation across various pages

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68497e3dbc7c832aa158df2214aea11d