### PR TITLE
Refactor pages to Material UI

### DIFF
--- a/pages/GardenStatisticsPage.tsx
+++ b/pages/GardenStatisticsPage.tsx
@@ -1,23 +1,23 @@
 import React from 'react';
 import DashboardStats from '../components/DashboardStats';
 import { Link } from 'react-router-dom';
+import { Box, Typography, Paper, Button as MuiButton } from '@mui/material';
 
 const GardenStatisticsPage: React.FC = () => {
   return (
-    <div className="p-4 bg-slate-900 min-h-full text-slate-100 space-y-8 w-full">
-      <div className="flex justify-between items-center mb-6">
-        <h1 className="text-3xl font-bold text-green-400">Estatísticas do Jardim</h1>
-        <Link 
-          to="/"
-          className="bg-slate-700 hover:bg-slate-600 text-white font-semibold px-4 py-2 rounded-lg shadow transition-colors"
-        >
+    <Box p={4} bgcolor="background.default" color="text.primary" minHeight="100%" width="100%">
+      <Box display="flex" justifyContent="space-between" alignItems="center" mb={6}>
+        <Typography variant="h4" color="primary" fontWeight="bold">
+          Estatísticas do Jardim
+        </Typography>
+        <MuiButton component={Link} to="/" variant="contained" color="primary">
           Voltar ao Dashboard
-        </Link>
-      </div>
-      <div className="bg-white dark:bg-slate-800 p-5 sm:p-8 rounded-xl shadow-xl transition-colors duration-300">
+        </MuiButton>
+      </Box>
+      <Paper sx={{ p: { xs: 2.5, sm: 4 } }}>
         <DashboardStats />
-      </div>
-    </div>
+      </Paper>
+    </Box>
   );
 };
 

--- a/pages/GrowDetailPage.tsx
+++ b/pages/GrowDetailPage.tsx
@@ -9,6 +9,16 @@ import Toast from '../components/Toast';
 import Modal from '../components/Modal';
 import GrowQrCodeDisplay from '../components/GrowQrCodeDisplay';
 import { addMassDiaryEntry } from '../services/plantService';
+import {
+  Box,
+  Typography,
+  Breadcrumbs,
+  Paper,
+  IconButton,
+  List,
+  ListItem,
+  TextField,
+} from '@mui/material';
 
 export default function GrowDetailPage() {
   const { growId } = useParams<{ growId: string }>();
@@ -83,80 +93,88 @@ export default function GrowDetailPage() {
 
   if (loading) {
     return (
-      <div className="flex flex-col items-center justify-center min-h-full p-6">
+      <Box display="flex" flexDirection="column" alignItems="center" justifyContent="center" minHeight="100%" p={6}>
         <Loader message="Carregando espaço..." size="md" />
-      </div>
+      </Box>
     );
   }
 
   if (!grow) {
     return (
-      <div className="flex flex-col items-center justify-center min-h-full p-6">
+      <Box display="flex" flexDirection="column" alignItems="center" justifyContent="center" minHeight="100%" p={6}>
         Espaço não encontrado
-      </div>
+      </Box>
     );
   }
 
   return (
-    <div className="max-w-lg mx-auto w-full min-h-full flex flex-col gap-3 bg-white dark:bg-slate-900 p-2 sm:p-4">
+    <Box maxWidth="lg" mx="auto" width="100%" minHeight="100%" display="flex" flexDirection="column" gap={2} bgcolor="background.paper" p={{ xs: 2, sm: 4 }}>
       {toast && <Toast message={toast.message} type={toast.type} />}
-      <div className="sticky top-0 z-20 bg-white/80 dark:bg-slate-900/80 flex items-center gap-2 py-2 px-1 sm:px-0 -mx-2 sm:mx-0 backdrop-blur-md mb-2">
-        <button
-          onClick={() => navigate(-1)}
-          className="p-2 rounded-full hover:bg-green-100 dark:hover:bg-green-900 transition focus:outline-none focus:ring-2 focus:ring-green-400"
-          aria-label="Voltar"
-        >
-          <ArrowLeftIcon className="w-7 h-7 text-green-700" />
-        </button>
-        <nav className="text-xs text-gray-500 dark:text-gray-400 flex gap-1">
-          <Link to="/" className="hover:underline">Dashboard</Link>
-          <span>&gt;</span>
-          <Link to="/grows" className="hover:underline">Grows</Link>
-          <span>&gt;</span>
-          <span className="font-bold text-green-700 dark:text-green-300">{grow.name}</span>
-        </nav>
-        <div className="flex-1" />
+      <Box
+        position="sticky"
+        top={0}
+        zIndex={20}
+        display="flex"
+        alignItems="center"
+        gap={1}
+        py={1}
+        px={{ xs: 1, sm: 0 }}
+        mb={2}
+        sx={{ backdropFilter: 'blur(4px)', bgcolor: 'background.paper' }}
+      >
+        <IconButton onClick={() => navigate(-1)} aria-label="Voltar" color="primary">
+          <ArrowLeftIcon className="w-7 h-7" />
+        </IconButton>
+        <Breadcrumbs separator=">">
+          <Link to="/">Dashboard</Link>
+          <Link to="/grows">Grows</Link>
+          <Typography color="text.primary">{grow.name}</Typography>
+        </Breadcrumbs>
+        <Box flexGrow={1} />
         <Link to={`/novo-cultivo?growId=${grow.id}`}>
-          <Button variant="primary" size="icon" className="shadow" title="Novo Plantio">
+          <Button variant="primary" size="icon" title="Novo Plantio">
             <PlusIcon className="w-5 h-5" />
           </Button>
         </Link>
-      </div>
+      </Box>
 
-      <h1 className="text-2xl font-extrabold text-green-700 dark:text-green-300 mt-2 mb-2">{grow.name}</h1>
-      {grow.location && <p className="text-sm text-gray-500 dark:text-gray-400">{grow.location}</p>}
-      {grow.capacity && <p className="text-sm text-gray-500 dark:text-gray-400">Capacidade: {grow.capacity}</p>}
-      <button
-        onClick={() => setShowQrModal(true)}
-        className="mt-2 text-xs px-2 py-1 bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 rounded hover:bg-blue-200 dark:hover:bg-blue-800 transition w-max"
-      >
-        Ver QR Code
-      </button>
+      <Typography variant="h5" color="primary" fontWeight="bold" mt={2} mb={1}>
+        {grow.name}
+      </Typography>
+      {grow.location && <Typography variant="body2" color="text.secondary">{grow.location}</Typography>}
+      {grow.capacity && <Typography variant="body2" color="text.secondary">Capacidade: {grow.capacity}</Typography>}
+      <Button variant="secondary" size="sm" onClick={() => setShowQrModal(true)} sx={{ mt: 1, width: 'max-content' }}>Ver QR Code</Button>
 
-      <div className="mt-4">
+      <Box mt={3}>
         {cultivos.length ? (
-          <ul className="space-y-2">
+          <List>
             {cultivos.map(c => (
-              <li key={c.id} className="p-3 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md">
-                <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2">
-                  <div className="flex flex-col">
-                    <span className="font-semibold text-gray-800 dark:text-gray-100">{c.name}</span>
-                    <span className="text-xs text-gray-500 dark:text-gray-400">{new Date(c.startDate).toLocaleDateString()}</span>
-                  </div>
-                  <div className="flex gap-2">
-                    <Link to={`/cultivo/${c.id}`}>
-                      <Button variant="primary" size="sm">Selecionar Plantio</Button>
-                    </Link>
-                    <Button variant="secondary" size="sm" onClick={() => openMassModal(c)}>Registrar Ação em Massa</Button>
-                  </div>
-                </div>
-              </li>
+              <ListItem key={c.id} sx={{ p: 0, mb: 1 }}>
+                <Paper sx={{ p: 2, width: '100%' }} variant="outlined">
+                  <Box display="flex" flexDirection={{ xs: 'column', sm: 'row' }} alignItems={{ sm: 'center' }} justifyContent="space-between" gap={2}>
+                    <Box>
+                      <Typography fontWeight="bold">{c.name}</Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        {new Date(c.startDate).toLocaleDateString()}
+                      </Typography>
+                    </Box>
+                    <Box display="flex" gap={1}>
+                      <Link to={`/cultivo/${c.id}`}> 
+                        <Button variant="primary" size="sm">Selecionar Plantio</Button>
+                      </Link>
+                      <Button variant="secondary" size="sm" onClick={() => openMassModal(c)}>
+                        Registrar Ação em Massa
+                      </Button>
+                    </Box>
+                  </Box>
+                </Paper>
+              </ListItem>
             ))}
-          </ul>
+          </List>
         ) : (
-          <div className="text-gray-400 dark:text-gray-500">Nenhum plantio neste espaço.</div>
+          <Typography color="text.secondary">Nenhum plantio neste espaço.</Typography>
         )}
-      </div>
+      </Box>
       {grow && (
         <Modal isOpen={showQrModal} onClose={() => setShowQrModal(false)} title="QR Code do Espaço">
           <GrowQrCodeDisplay grow={grow} />
@@ -164,69 +182,67 @@ export default function GrowDetailPage() {
       )}
       {selectedCultivo && (
         <Modal isOpen={showMassModal} onClose={() => setShowMassModal(false)} title="Registro em Massa" maxWidth="sm">
-          <div className="flex flex-col gap-3 p-2">
-            <input
+          <Box display="flex" flexDirection="column" gap={2} p={2}>
+            <TextField
               type="number"
-              className="p-2 border rounded"
-              placeholder="Volume de Rega (L)"
+              label="Volume de Rega (L)"
               value={massWateringVolume}
               onChange={e => setMassWateringVolume(e.target.value)}
+              fullWidth
             />
-            <input
-              type="text"
-              className="p-2 border rounded"
-              placeholder="Tipo de Água/Solução"
+            <TextField
+              label="Tipo de Água/Solução"
               value={massWateringType}
               onChange={e => setMassWateringType(e.target.value)}
+              fullWidth
             />
-            <input
-              type="text"
-              className="p-2 border rounded"
-              placeholder="Tipo de Fertilizante"
+            <TextField
+              label="Tipo de Fertilizante"
               value={massFertilizationType}
               onChange={e => setMassFertilizationType(e.target.value)}
+              fullWidth
             />
-            <input
+            <TextField
               type="number"
-              className="p-2 border rounded"
-              placeholder="Concentração do Fertilizante"
+              label="Concentração do Fertilizante"
               value={massFertilizationConcentration}
               onChange={e => setMassFertilizationConcentration(e.target.value)}
+              fullWidth
             />
-            <input
-              type="text"
-              className="p-2 border rounded"
-              placeholder="Fotoperíodo (ex: 12/12)"
+            <TextField
+              label="Fotoperíodo (ex: 12/12)"
               value={massPhotoperiod}
               onChange={e => setMassPhotoperiod(e.target.value)}
+              fullWidth
             />
-            <input
-              type="text"
-              className="p-2 border rounded"
-              placeholder="Produto de Pulverização"
+            <TextField
+              label="Produto de Pulverização"
               value={massSprayProduct}
               onChange={e => setMassSprayProduct(e.target.value)}
+              fullWidth
             />
-            <input
+            <TextField
               type="number"
-              className="p-2 border rounded"
-              placeholder="Quantidade Pulverizada"
+              label="Quantidade Pulverizada"
               value={massSprayAmount}
               onChange={e => setMassSprayAmount(e.target.value)}
+              fullWidth
             />
-            <textarea
-              className="p-2 border rounded"
-              placeholder="Notas"
+            <TextField
+              label="Notas"
+              multiline
+              minRows={2}
               value={massNotes}
               onChange={e => setMassNotes(e.target.value)}
+              fullWidth
             />
-            <div className="flex gap-3 mt-2">
+            <Box display="flex" gap={1} mt={1}>
               <Button variant="secondary" onClick={() => setShowMassModal(false)}>Cancelar</Button>
               <Button variant="primary" onClick={handleMassRegister} disabled={!massNotes && !massWateringVolume && !massFertilizationType && !massPhotoperiod && !massSprayProduct}>Salvar</Button>
-            </div>
-          </div>
+            </Box>
+          </Box>
         </Modal>
       )}
-    </div>
+    </Box>
   );
 }

--- a/pages/GrowsPage.tsx
+++ b/pages/GrowsPage.tsx
@@ -6,6 +6,15 @@ import ArrowLeftIcon from '../components/icons/ArrowLeftIcon';
 import PlusIcon from '../components/icons/PlusIcon';
 import Toast from '../components/Toast';
 import Loader from "../components/Loader";
+import {
+  Box,
+  Typography,
+  Breadcrumbs,
+  Paper,
+  IconButton,
+  List,
+  ListItem,
+} from '@mui/material';
 
 export default function GrowsPage() {
   const [grows, setGrows] = useState<Grow[]>([]);
@@ -43,58 +52,80 @@ export default function GrowsPage() {
 
   if (loading) {
     return (
-      <div className="flex flex-col items-center justify-center min-h-full p-6">
+      <Box display="flex" flexDirection="column" alignItems="center" justifyContent="center" minHeight="100%" p={6}>
         <Loader message="Carregando estufas..." size="md" />
-      </div>
+      </Box>
     );
   }
 
   return (
-    <div className="max-w-lg mx-auto w-full min-h-full flex flex-col gap-3 bg-white dark:bg-slate-900 p-2 sm:p-4">
+    <Box maxWidth="lg" mx="auto" width="100%" minHeight="100%" display="flex" flexDirection="column" gap={2} bgcolor="background.paper" p={{ xs: 2, sm: 4 }}>
       {toast && <Toast message={toast.message} type={toast.type} />}
-      <div className="sticky top-0 z-20 bg-white/80 dark:bg-slate-900/80 flex items-center gap-2 py-2 px-1 sm:px-0 -mx-2 sm:mx-0 backdrop-blur-md mb-2">
-        <button
-          onClick={() => navigate(-1)}
-          className="p-2 rounded-full hover:bg-green-100 dark:hover:bg-green-900 transition focus:outline-none focus:ring-2 focus:ring-green-400"
-          aria-label="Voltar"
-        >
-          <ArrowLeftIcon className="w-7 h-7 text-green-700" />
-        </button>
-        <nav className="text-xs text-gray-500 dark:text-gray-400 flex gap-1">
-          <Link to="/" className="hover:underline">Dashboard</Link>
-          <span>&gt;</span>
-          <span className="font-bold text-green-700 dark:text-green-300">Grows</span>
-        </nav>
-        <div className="flex-1" />
+      <Box
+        position="sticky"
+        top={0}
+        zIndex={20}
+        bgcolor="background.paper"
+        display="flex"
+        alignItems="center"
+        gap={1}
+        py={1}
+        px={{ xs: 1, sm: 0 }}
+        mb={2}
+        sx={{ backdropFilter: 'blur(4px)' }}
+      >
+        <IconButton onClick={() => navigate(-1)} aria-label="Voltar" color="primary">
+          <ArrowLeftIcon className="w-7 h-7" />
+        </IconButton>
+        <Breadcrumbs separator=">">
+          <Link to="/">Dashboard</Link>
+          <Typography color="text.primary">Grows</Typography>
+        </Breadcrumbs>
+        <Box flexGrow={1} />
         <Link to="/novo-grow">
-          <Button variant="primary" size="icon" className="shadow" title="Novo Grow">
+          <Button variant="primary" size="icon" title="Novo Grow">
             <PlusIcon className="w-5 h-5" />
           </Button>
         </Link>
-      </div>
+      </Box>
 
-      <h1 className="text-2xl font-extrabold text-green-700 dark:text-green-300 mt-4 mb-2">Meus Grows</h1>
+      <Typography variant="h4" color="primary" fontWeight="bold" mt={2} mb={2}>
+        Meus Grows
+      </Typography>
 
-      <div className="mt-6">
+      <Box mt={3}>
         {grows.length ? (
-          <ul className="space-y-2">
+          <List>
             {grows.map(g => (
-              <li key={g.id} className="p-3 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md">
-                <Link to={`/grow/${g.id}`} className="block">
-                  <div className="font-semibold text-gray-800 dark:text-gray-100">{g.name}</div>
-                  {g.location && <div className="text-sm text-gray-500 dark:text-gray-400">{g.location}</div>}
-                  {g.capacity && <div className="text-sm text-gray-500 dark:text-gray-400">Capacidade: {g.capacity}</div>}
-                </Link>
-              </li>
+              <ListItem key={g.id} sx={{ p: 0, mb: 1 }}>
+                <Paper sx={{ p: 2, width: '100%' }} variant="outlined">
+                  <Link to={`/grow/${g.id}`} style={{ textDecoration: 'none' }}>
+                    <Typography fontWeight="bold" color="text.primary">
+                      {g.name}
+                    </Typography>
+                    {g.location && (
+                      <Typography variant="body2" color="text.secondary">
+                        {g.location}
+                      </Typography>
+                    )}
+                    {g.capacity && (
+                      <Typography variant="body2" color="text.secondary">
+                        Capacidade: {g.capacity}
+                      </Typography>
+                    )}
+                  </Link>
+                </Paper>
+              </ListItem>
             ))}
-          </ul>
+          </List>
         ) : (
-          <div className="text-gray-400 dark:text-gray-500 text-center py-8">
-            Nenhum grow cadastrado ainda.<br />
-            <Link to="/novo-grow" className="underline text-green-700 dark:text-green-300">Crie sua primeira estufa</Link>
-          </div>
+          <Typography color="text.secondary" textAlign="center" py={4}>
+            Nenhum grow cadastrado ainda.
+            <br />
+            <Link to="/novo-grow">Crie sua primeira estufa</Link>
+          </Typography>
         )}
-      </div>
-    </div>
+      </Box>
+    </Box>
   );
 }

--- a/pages/NovoGrowPage.tsx
+++ b/pages/NovoGrowPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, Link } from 'react-router-dom';
 import Button from '../components/Button';
 import ArrowLeftIcon from '../components/icons/ArrowLeftIcon';
 import Toast from '../components/Toast';
+import { Box, Typography, TextField, Breadcrumbs, IconButton, Paper } from '@mui/material';
 
 export default function NovoGrowPage() {
   const [name, setName] = useState('');
@@ -35,55 +36,66 @@ export default function NovoGrowPage() {
     }
   };
 
-  const inputStyle = "w-full px-3 py-2 text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-green-500";
-  const labelStyle = "block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1";
-
   return (
-    <div className="max-w-lg mx-auto w-full min-h-full flex flex-col gap-3 bg-white dark:bg-slate-900 p-2 sm:p-4">
+    <Box maxWidth="sm" mx="auto" width="100%" minHeight="100%" display="flex" flexDirection="column" gap={2} p={{ xs: 2, sm: 4 }}>
       {toast && <Toast message={toast.message} type={toast.type} />}
-      <div className="sticky top-0 z-20 bg-white/80 dark:bg-slate-900/80 flex items-center gap-2 py-2 px-1 sm:px-0 -mx-2 sm:mx-0 backdrop-blur-md mb-2">
-        <button
-          onClick={() => navigate(-1)}
-          className="p-2 rounded-full hover:bg-green-100 dark:hover:bg-green-900 transition focus:outline-none focus:ring-2 focus:ring-green-400"
-          aria-label="Voltar"
-        >
-          <ArrowLeftIcon className="w-7 h-7 text-green-700" />
-        </button>
-        <nav className="text-xs text-gray-500 dark:text-gray-400 flex gap-1">
-          <Link to="/" className="hover:underline">Dashboard</Link>
-          <span>&gt;</span>
-          <Link to="/grows" className="hover:underline">Grows</Link>
-          <span>&gt;</span>
-          <span className="font-bold text-green-700 dark:text-green-300">Novo Grow</span>
-        </nav>
-      </div>
-      <div className="bg-white dark:bg-gray-800 shadow-xl rounded-lg p-4 sm:p-6 flex-1 flex flex-col">
-        <h1 className="text-2xl sm:text-3xl font-extrabold text-green-700 dark:text-green-300 mb-6 text-center">Novo Grow</h1>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
-            <label htmlFor="growName" className={labelStyle}>Nome do Grow</label>
-            <input id="growName" type="text" className={inputStyle} value={name} onChange={e => setName(e.target.value)} required />
-          </div>
-          <div>
-            <label htmlFor="growLocation" className={labelStyle}>Localização (opcional)</label>
-            <input id="growLocation" type="text" className={inputStyle} value={location} onChange={e => setLocation(e.target.value)} />
-          </div>
-          <div>
-            <label htmlFor="growCapacity" className={labelStyle}>Capacidade (opcional)</label>
-            <input
-              id="growCapacity"
-              type="number"
-              className={inputStyle}
-              value={capacity}
-              onChange={e => setCapacity(e.target.value === '' ? '' : parseInt(e.target.value))}
-              min="0"
-            />
-          </div>
-          <div className="mt-6 flex justify-center">
-            <Button type="submit" variant="primary" size="lg" loading={saving} disabled={!name}>Salvar Grow</Button>
-          </div>
-        </form>
-      </div>
-    </div>
+      <Box
+        position="sticky"
+        top={0}
+        zIndex={20}
+        display="flex"
+        alignItems="center"
+        gap={1}
+        py={1}
+        px={{ xs: 1, sm: 0 }}
+        mb={2}
+        sx={{ backdropFilter: 'blur(4px)', bgcolor: 'background.paper' }}
+      >
+        <IconButton onClick={() => navigate(-1)} aria-label="Voltar" color="primary">
+          <ArrowLeftIcon className="w-7 h-7" />
+        </IconButton>
+        <Breadcrumbs separator=">">
+          <Link to="/">Dashboard</Link>
+          <Link to="/grows">Grows</Link>
+          <Typography color="text.primary">Novo Grow</Typography>
+        </Breadcrumbs>
+      </Box>
+      <Paper sx={{ p: { xs: 2, sm: 3 }, flex: 1 }}>
+        <Typography variant="h5" color="primary" fontWeight="bold" textAlign="center" mb={3}>
+          Novo Grow
+        </Typography>
+        <Box component="form" onSubmit={handleSubmit} display="flex" flexDirection="column" gap={2}>
+          <TextField
+            id="growName"
+            label="Nome do Grow"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            required
+            fullWidth
+          />
+          <TextField
+            id="growLocation"
+            label="Localização (opcional)"
+            value={location}
+            onChange={e => setLocation(e.target.value)}
+            fullWidth
+          />
+          <TextField
+            id="growCapacity"
+            label="Capacidade (opcional)"
+            type="number"
+            value={capacity}
+            onChange={e => setCapacity(e.target.value === '' ? '' : parseInt(e.target.value))}
+            inputProps={{ min: 0 }}
+            fullWidth
+          />
+          <Box mt={3} textAlign="center">
+            <Button type="submit" variant="primary" size="lg" loading={saving} disabled={!name}>
+              Salvar Grow
+            </Button>
+          </Box>
+        </Box>
+      </Paper>
+    </Box>
   );
 }


### PR DESCRIPTION
## Summary
- migrate GrowsPage, NovoGrowPage, GrowDetailPage and GardenStatisticsPage to Material UI components

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684980166164832aa8f683c587ef95a4