### PR TITLE
Fix toast usage and missing labels

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -29,6 +29,18 @@ export const PLANT_OPERATIONAL_STATUS_OPTIONS = [
   { value: PlantOperationalStatus.ARCHIVED, label: 'Arquivada' },
 ];
 
+export const PLANT_HEALTH_STATUS_LABELS: Record<PlantHealthStatus, string> =
+  PLANT_HEALTH_STATUS_OPTIONS.reduce((acc, { value, label }) => {
+    acc[value as PlantHealthStatus] = label;
+    return acc;
+  }, {} as Record<PlantHealthStatus, string>);
+
+export const PLANT_OPERATIONAL_STATUS_LABELS: Record<PlantOperationalStatus, string> =
+  PLANT_OPERATIONAL_STATUS_OPTIONS.reduce((acc, { value, label }) => {
+    acc[value as PlantOperationalStatus] = label;
+    return acc;
+  }, {} as Record<PlantOperationalStatus, string>);
+
 export const CULTIVATION_TYPE_OPTIONS = [
   { value: 'Indoor', label: 'Indoor' },
   { value: 'Outdoor', label: 'Outdoor' },

--- a/pages/CultivosPage.tsx
+++ b/pages/CultivosPage.tsx
@@ -64,7 +64,7 @@ const CultivosPage: React.FC = () => {
 
   return (
     <Container maxWidth="sm" sx={{ py: 2 }}>
-      {toast && <Toast message={toast.message} type={toast.type} />}
+      {toast && <Toast toast={toast} />}
 
       <Header
         title={t('sidebar.cultivos')}

--- a/pages/GrowsPage.tsx
+++ b/pages/GrowsPage.tsx
@@ -55,3 +55,75 @@ export default function GrowsPage() {
       </Box>
     );
   }
+  return (
+    <Box
+      maxWidth="lg"
+      mx="auto"
+      width="100%"
+      minHeight="100%"
+      display="flex"
+      flexDirection="column"
+      gap={2}
+      bgcolor="background.paper"
+      p={{ xs: 2, sm: 4 }}
+    >
+      {toast && <Toast toast={toast} />}
+
+      <Header
+        title={t('growsPage.title')}
+        showBack
+        onBack={() => navigate(-1)}
+        onOpenAddModal={() => navigate('/novo-grow')}
+        onOpenScannerModal={() => {}}
+      />
+
+      <Breadcrumbs
+        items={[
+          { label: t('growsPage.breadcrumb.dashboard'), to: '/' },
+          { label: t('growsPage.breadcrumb.grows') },
+        ]}
+        className="px-1 sm:px-0 mb-2"
+      />
+
+      <Typography variant="h4" color="primary" fontWeight="bold">
+        {t('growsPage.title')}
+      </Typography>
+
+      <Box mt={3}>
+        {grows.length ? (
+          <List>
+            {grows.map(g => (
+              <ListItem key={g.id} sx={{ p: 0, mb: 1 }}>
+                <Paper sx={{ p: 2, width: '100%' }} variant="outlined">
+                  <Link to={`/grow/${g.id}`} style={{ textDecoration: 'none' }}>
+                    <Typography fontWeight="bold" color="text.primary">
+                      {g.name}
+                    </Typography>
+                    {g.location && (
+                      <Typography variant="body2" color="text.secondary">
+                        {g.location}
+                      </Typography>
+                    )}
+                    {g.capacity && (
+                      <Typography variant="body2" color="text.secondary">
+                        {t('growsPage.capacity')}: {g.capacity}
+                      </Typography>
+                    )}
+                  </Link>
+                </Paper>
+              </ListItem>
+            ))}
+          </List>
+        ) : (
+          <Typography color="text.secondary" textAlign="center" py={4}>
+            {t('growsPage.no_grows')}
+            <br />
+            <Link to="/novo-grow" style={{ textDecoration: 'underline', color: 'green' }}>
+              {t('growsPage.create_first')}
+            </Link>
+          </Typography>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/pages/NovaPlantaPage.tsx
+++ b/pages/NovaPlantaPage.tsx
@@ -68,7 +68,7 @@ export default function GrowsPage() {
       bgcolor="background.paper"
       p={{ xs: 2, sm: 4 }}
     >
-      {toast && <Toast message={toast.message} type={toast.type} />}
+      {toast && <Toast toast={toast} />}
 
       <Header
         title={t('growsPage.title')}

--- a/pages/NovoCultivoPage.tsx
+++ b/pages/NovoCultivoPage.tsx
@@ -113,7 +113,7 @@ export default function NovoCultivoPage() {
 
   return (
     <Box className="mx-auto w-full max-w-3xl p-4 flex flex-col gap-4 bg-white dark:bg-gray-900">
-      {toast && <Toast message={toast.message} type={toast.type} />}
+      {toast && <Toast toast={toast} />}
 
       <Box className="sticky top-0 z-20 bg-white dark:bg-gray-900 backdrop-blur p-2 flex items-center gap-2 mb-4">
         <IconButton onClick={() => navigate(-1)} color="primary">

--- a/pages/NovoGrowPage.tsx
+++ b/pages/NovoGrowPage.tsx
@@ -55,7 +55,7 @@ export default function NovoGrowPage() {
       bgcolor="background.paper"
       p={{ xs: 2, sm: 4 }}
     >
-      {toast && <Toast message={toast.message} type={toast.type} />}
+      {toast && <Toast toast={toast} />}
 
       <Box
         position="sticky"

--- a/pages/PlantDetailPage.tsx
+++ b/pages/PlantDetailPage.tsx
@@ -202,7 +202,7 @@ const PlantDetailPage: React.FC = () => {
           showBack
           onBack={()=>navigate(-1)}
         />
-        {toast && <Toast message={toast.message} type={toast.type} />}
+        {toast && <Toast toast={toast} />}
         <main className="flex-1 max-w-7xl mx-auto w-full p-4">
           {/* QRCode hidden for download*/}
           <div style={{ display:'none' }}>


### PR DESCRIPTION
## Summary
- pass toast object correctly to Toast component across pages
- restore GrowsPage content and show list of grows
- add `PLANT_HEALTH_STATUS_LABELS` and `PLANT_OPERATIONAL_STATUS_LABELS`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6849911f8a00832a99398a31706a4b8c