### PR TITLE
Fix Netlify deploy failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite --host 0.0.0.0",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "node --test netlify/functions/deleteDiaryEntry.test.js"
+    "test": "node --test tests/deleteDiaryEntry.test.js"
   },
   "dependencies": {
     "@emotion/react": "^11.11.4",

--- a/tests/deleteDiaryEntry.test.js
+++ b/tests/deleteDiaryEntry.test.js
@@ -4,7 +4,7 @@ import { readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { transformSync } from 'esbuild';
 
-const tsSource = readFileSync(new URL('./deleteDiaryEntry.ts', import.meta.url), 'utf8');
+const tsSource = readFileSync(new URL('../netlify/functions/deleteDiaryEntry.ts', import.meta.url), 'utf8');
 const { code } = transformSync(tsSource, { loader: 'ts', format: 'esm' });
 const outfile = join(process.cwd(), 'deleteDiaryEntry.compiled.mjs');
 writeFileSync(outfile, code);


### PR DESCRIPTION
## Summary
- remove test file from serverless functions directory
- update test script path

## Testing
- `npm test` *(fails: Cannot find package 'esbuild')*

------
https://chatgpt.com/codex/tasks/task_e_6849d1813964832a95e7b6c68e09e2de