### PR TITLE
Fix circular dependency between services

### DIFF
--- a/services/cultivoService.ts
+++ b/services/cultivoService.ts
@@ -1,5 +1,5 @@
 import { Cultivo, Plant } from '../types';
-import { convertKeysToCamelCase } from './plantService';
+import { convertKeysToCamelCase } from '../utils/caseUtils';
 import { loadNetlifyIdentity } from '../utils/loadNetlifyIdentity';
 import logger from '../utils/logger';
 

--- a/services/plantService.ts
+++ b/services/plantService.ts
@@ -3,6 +3,7 @@
 import { Plant, DiaryEntry, NewPlantData } from '../types';
 import { loadNetlifyIdentity } from '../utils/loadNetlifyIdentity';
 import logger from '../utils/logger';
+import { convertKeysToCamelCase } from '../utils/caseUtils';
 
 const API_BASE_URL = '/.netlify/functions';
 
@@ -87,20 +88,7 @@ const fetchWithAuth = async (endpoint: string, options: RequestInit = {}) => {
 };
 
 // --- Funções utilitárias para conversão de snake_case para camelCase ---
-function snakeToCamel(s: string) {
-  return s.replace(/_([a-z])/g, g => g[1].toUpperCase());
-}
-
-export function convertKeysToCamelCase(obj: any): any {
-  if (Array.isArray(obj)) {
-    return obj.map(v => convertKeysToCamelCase(v));
-  } else if (obj && typeof obj === 'object') {
-    return Object.fromEntries(
-      Object.entries(obj).map(([k, v]) => [snakeToCamel(k), convertKeysToCamelCase(v)])
-    );
-  }
-  return obj;
-}
+// As funções foram movidas para '../utils/caseUtils' para evitar dependências circulares
 
 // --- Funções CRUD para Plantas ---
 

--- a/utils/caseUtils.ts
+++ b/utils/caseUtils.ts
@@ -1,0 +1,14 @@
+export function snakeToCamel(str: string): string {
+  return str.replace(/_([a-z])/g, g => g[1].toUpperCase());
+}
+
+export function convertKeysToCamelCase(obj: any): any {
+  if (Array.isArray(obj)) {
+    return obj.map(v => convertKeysToCamelCase(v));
+  } else if (obj && typeof obj === 'object') {
+    return Object.fromEntries(
+      Object.entries(obj).map(([k, v]) => [snakeToCamel(k), convertKeysToCamelCase(v)])
+    );
+  }
+  return obj;
+}


### PR DESCRIPTION
## Summary
- move `convertKeysToCamelCase` to `utils/caseUtils`
- use the shared util in `plantService` and `cultivoService`

## Testing
- `npm test` *(fails: Cannot find package 'esbuild')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684adc607458832a81b0ca9be652fc60