### PR TITLE
Fix circular dependency between services

### DIFF
--- a/pages/AllPlantsPage.tsx
+++ b/pages/AllPlantsPage.tsx
@@ -12,6 +12,7 @@ import Button from '../components/Button';
 import Toast from '../components/Toast';
 import useToast from '../hooks/useToast';
 import { Cultivo } from '../types';
+import { getCultivos } from '../services/cultivoService';
 import {
   Box,
   Container,
@@ -38,7 +39,7 @@ const AllPlantsPage: React.FC = () => {
 
   React.useEffect(() => {
     if (selectionMode) {
-      import('../services/cultivoService').then(m => m.getCultivos().then(setCultivos).catch(() => setCultivos([])));
+      getCultivos().then(setCultivos).catch(() => setCultivos([]));
     }
   }, [selectionMode]);
 

--- a/pages/CultivoDetailPage.tsx
+++ b/pages/CultivoDetailPage.tsx
@@ -17,7 +17,7 @@ import CheckCircleIcon from '../components/icons/CheckCircleIcon';
 import LeafIcon from '../components/icons/LeafIcon';
 import PlusIcon from '../components/icons/PlusIcon';
 import { useTranslation } from 'react-i18next';
-import { getPlantsByCultivo, updateCultivo } from '../services/cultivoService';
+import { getCultivos, getPlantsByCultivo, updateCultivo } from '../services/cultivoService';
 import { getGrows } from '../services/growService';
 import { updatePlant } from '../services/plantService';
 import logger from '../utils/logger';
@@ -46,7 +46,6 @@ const CultivoDetailPage: React.FC = () => {
     setLoading(true);
     (async () => {
       try {
-        const { getCultivos } = await import('../services/cultivoService');
         const all = await getCultivos();
         setCultivo(all.find(c => c.id === cultivoId) || null);
         setGrows(await getGrows());

--- a/pages/CultivoEtiquetasPage.tsx
+++ b/pages/CultivoEtiquetasPage.tsx
@@ -6,6 +6,7 @@ import Button from '../components/Button';
 import Toast from '../components/Toast';
 import { Plant } from '../types';
 import { useTranslation } from 'react-i18next';
+import { getPlantsByCultivo } from '../services/cultivoService';
 
 export default function CultivoEtiquetasPage() {
   const { cultivoId } = useParams<{ cultivoId: string }>();
@@ -15,15 +16,15 @@ export default function CultivoEtiquetasPage() {
 
   useEffect(() => {
     if (cultivoId) {
-      import('../services/cultivoService').then(({ getPlantsByCultivo }) => {
-        getPlantsByCultivo(cultivoId).then(setPlants).catch((err) => {
+      getPlantsByCultivo(cultivoId)
+        .then(setPlants)
+        .catch((err) => {
           setPlants([]);
-          showToast({ 
+          showToast({
             message: t('cultivoEtiquetasPage.error_loading_plants', { error: err.message || err }),
-            type: 'error' 
+            type: 'error'
           });
         });
-      });
     }
   }, [cultivoId, showToast, t]);
 

--- a/pages/CultivosPage.tsx
+++ b/pages/CultivosPage.tsx
@@ -10,6 +10,7 @@ import Toast from '../components/Toast';
 import LeafIcon from '../components/icons/LeafIcon';
 import Loader from '../components/Loader';
 import ErrorBanner from '../components/ErrorBanner';
+import { getCultivos } from '../services/cultivoService';
 
 const CultivosPage: React.FC = () => {
   const { t } = useTranslation();
@@ -23,11 +24,9 @@ const CultivosPage: React.FC = () => {
     let mounted = true;
     async function fetchCultivos() {
       try {
-        const { getCultivos } = await import('../services/cultivoService');
         const data = await getCultivos();
         if (mounted) setCultivos(data);
       } catch {
-        // Error handled, variable not used
         setError(t('cultivosPage.error_loading'));
       } finally {
         if (mounted) setLoading(false);

--- a/pages/GardenStatisticsPage.tsx
+++ b/pages/GardenStatisticsPage.tsx
@@ -6,6 +6,7 @@ import Button from '../components/Button';
 import Toast from '../components/Toast';
 import { Plant } from '../types';
 import { useTranslation } from 'react-i18next';
+import { getPlantsByCultivo } from '../services/cultivoService';
 
 export default function CultivoEtiquetasPage() {
   const { cultivoId } = useParams<{ cultivoId: string }>();
@@ -15,15 +16,15 @@ export default function CultivoEtiquetasPage() {
 
   useEffect(() => {
     if (cultivoId) {
-      import('../services/cultivoService').then(({ getPlantsByCultivo }) => {
-        getPlantsByCultivo(cultivoId).then(setPlants).catch((err) => {
+      getPlantsByCultivo(cultivoId)
+        .then(setPlants)
+        .catch((err) => {
           setPlants([]);
-          showToast({ 
+          showToast({
             message: t('cultivoEtiquetasPage.error_loading_plants', { error: err.message || err }),
-            type: 'error' 
+            type: 'error'
           });
         });
-      });
     }
   }, [cultivoId, showToast, t]);
 

--- a/pages/GrowDetailPage.tsx
+++ b/pages/GrowDetailPage.tsx
@@ -15,6 +15,8 @@ import Modal from '../components/Modal';
 import GrowQrCodeDisplay from '../components/GrowQrCodeDisplay';
 import MassRegisterModal from '../components/grow/MassRegisterModal';
 import { addMassDiaryEntry } from '../services/plantService';
+import { getGrows } from '../services/growService';
+import { getCultivos } from '../services/cultivoService';
 import { Box, Typography, Paper, List, ListItem, IconButton } from '@mui/material';
 
 export default function GrowDetailPage() {
@@ -35,8 +37,6 @@ export default function GrowDetailPage() {
   useEffect(() => {
     async function fetchData() {
       try {
-        const { getGrows } = await import('../services/growService');
-        const { getCultivos } = await import('../services/cultivoService');
         const [growList, cultivosList] = await Promise.all([
           getGrows(),
           getCultivos(),

--- a/pages/GrowsPage.tsx
+++ b/pages/GrowsPage.tsx
@@ -18,6 +18,7 @@ import ArrowLeftIcon from '../components/icons/ArrowLeftIcon';
 import PlusIcon from '../components/icons/PlusIcon';
 import useToast from '../hooks/useToast';
 import { Grow } from '../types';
+import { getGrows } from '../services/growService';
 
 export default function GrowsPage() {
   const [grows, setGrows] = useState<Grow[]>([]);
@@ -30,7 +31,6 @@ export default function GrowsPage() {
   useEffect(() => {
     async function fetchData() {
       try {
-        const { getGrows } = await import('../services/growService');
         const data = await getGrows();
         setGrows(data);
       } catch (e) {

--- a/pages/NovaPlantaPage.tsx
+++ b/pages/NovaPlantaPage.tsx
@@ -17,6 +17,7 @@ import ArrowLeftIcon from '../components/icons/ArrowLeftIcon';
 import PlusIcon from '../components/icons/PlusIcon';
 import useToast from '../hooks/useToast';
 import { Grow } from '../types';
+import { getGrows } from '../services/growService';
 
 export default function GrowsPage() {
   const [grows, setGrows] = useState<Grow[]>([]);
@@ -28,7 +29,6 @@ export default function GrowsPage() {
   useEffect(() => {
     async function fetchData() {
       try {
-        const { getGrows } = await import('../services/growService');
         const data = await getGrows();
         setGrows(data);
       } catch (e) {

--- a/pages/NovoCultivoPage.tsx
+++ b/pages/NovoCultivoPage.tsx
@@ -16,6 +16,8 @@ import Breadcrumbs from '../components/Breadcrumbs';
 import { useTranslation } from 'react-i18next';
 import { usePlantContext } from '../contexts/PlantContext';
 import { SUBSTRATE_OPTIONS } from '../constants';
+import { addCultivo } from '../services/cultivoService';
+import { getGrows } from '../services/growService';
 import {
   Grow,
   PlantStage,
@@ -46,15 +48,9 @@ export default function NovoCultivoPage() {
 
   // Fetch available grows
   useEffect(() => {
-    (async () => {
-      try {
-        const { getGrows } = await import('../services/growService');
-        const data = await getGrows();
-        setGrows(data);
-      } catch (e) {
-        console.error('Erro ao carregar grows', e);
-      }
-    })();
+    getGrows()
+      .then(setGrows)
+      .catch(e => console.error('Erro ao carregar grows', e));
   }, []);
 
   const updatePlant = (
@@ -78,7 +74,6 @@ export default function NovoCultivoPage() {
     e.preventDefault();
     setSaving(true);
     try {
-      const { addCultivo } = await import('../services/cultivoService');
       const plantsToSend = plants
         .filter(p => p.name && p.strain)
         .map(p => ({

--- a/pages/NovoGrowPage.tsx
+++ b/pages/NovoGrowPage.tsx
@@ -13,6 +13,7 @@ import Toast from '../components/Toast';
 import useToast from '../hooks/useToast';
 import Breadcrumbs from '../components/Breadcrumbs';
 import { useTranslation } from 'react-i18next';
+import { addGrow } from '../services/growService';
 
 export default function NovoGrowPage() {
   const [name, setName] = useState('');
@@ -28,7 +29,6 @@ export default function NovoGrowPage() {
     if (!name) return;
     setSaving(true);
     try {
-      const { addGrow } = await import('../services/growService');
       const newGrow = await addGrow({
         name,
         location: location || undefined,

--- a/pages/PlantDetailPage.tsx
+++ b/pages/PlantDetailPage.tsx
@@ -20,6 +20,7 @@ import LeafIcon from '../components/icons/LeafIcon';
 import Toast from '../components/Toast';
 import useToast from '../hooks/useToast';
 import { useTranslation } from 'react-i18next';
+import { getCultivos } from '../services/cultivoService';
 
 const PlantDetailPage: React.FC = () => {
   const { plantId } = useParams<{ plantId: string }>();
@@ -101,8 +102,7 @@ const PlantDetailPage: React.FC = () => {
   }, [plantId, plant]);
 
   useEffect(() => {
-    import('../services/cultivoService')
-      .then(({ getCultivos }) => getCultivos())
+    getCultivos()
       .then(data => setCultivos(data))
       .catch(() => setCultivos([]));
   }, []);

--- a/services/cultivoService.ts
+++ b/services/cultivoService.ts
@@ -1,5 +1,5 @@
 import { Cultivo, Plant } from '../types';
-import { convertKeysToCamelCase } from './plantService';
+import { convertKeysToCamelCase } from '../utils/caseUtils';
 import { loadNetlifyIdentity } from '../utils/loadNetlifyIdentity';
 import logger from '../utils/logger';
 

--- a/services/plantService.ts
+++ b/services/plantService.ts
@@ -3,6 +3,7 @@
 import { Plant, DiaryEntry, NewPlantData } from '../types';
 import { loadNetlifyIdentity } from '../utils/loadNetlifyIdentity';
 import logger from '../utils/logger';
+import { convertKeysToCamelCase } from '../utils/caseUtils';
 
 const API_BASE_URL = '/.netlify/functions';
 
@@ -87,20 +88,7 @@ const fetchWithAuth = async (endpoint: string, options: RequestInit = {}) => {
 };
 
 // --- Funções utilitárias para conversão de snake_case para camelCase ---
-function snakeToCamel(s: string) {
-  return s.replace(/_([a-z])/g, g => g[1].toUpperCase());
-}
-
-export function convertKeysToCamelCase(obj: any): any {
-  if (Array.isArray(obj)) {
-    return obj.map(v => convertKeysToCamelCase(v));
-  } else if (obj && typeof obj === 'object') {
-    return Object.fromEntries(
-      Object.entries(obj).map(([k, v]) => [snakeToCamel(k), convertKeysToCamelCase(v)])
-    );
-  }
-  return obj;
-}
+// As funções foram movidas para '../utils/caseUtils' para evitar dependências circulares
 
 // --- Funções CRUD para Plantas ---
 

--- a/utils/caseUtils.ts
+++ b/utils/caseUtils.ts
@@ -1,0 +1,14 @@
+export function snakeToCamel(str: string): string {
+  return str.replace(/_([a-z])/g, g => g[1].toUpperCase());
+}
+
+export function convertKeysToCamelCase(obj: any): any {
+  if (Array.isArray(obj)) {
+    return obj.map(v => convertKeysToCamelCase(v));
+  } else if (obj && typeof obj === 'object') {
+    return Object.fromEntries(
+      Object.entries(obj).map(([k, v]) => [snakeToCamel(k), convertKeysToCamelCase(v)])
+    );
+  }
+  return obj;
+}


### PR DESCRIPTION
## Summary
- convert dynamic imports of `cultivoService` and `growService` to static imports
- run npm install so build/test work in the container

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684adc607458832a81b0ca9be652fc60